### PR TITLE
Include fix.

### DIFF
--- a/opencensus/stats/internal/measure_registry_impl.h
+++ b/opencensus/stats/internal/measure_registry_impl.h
@@ -16,7 +16,9 @@
 #define OPENCENSUS_STATS_INTERNAL_MEASURE_REGISTRY_IMPL_H_
 
 #include <cstdint>
+#include <string>
 #include <unordered_map>
+#include <vector>
 
 #include "absl/strings/string_view.h"
 #include "absl/synchronization/mutex.h"


### PR DESCRIPTION
Fixing includes which was causing build errors on some systems.  Transitive includes function differently on some versions of gcc.  It was failing to build on gcc 6.3.0
  