### PR TITLE
Use the same copts as ABSL.

### DIFF
--- a/opencensus/BUILD
+++ b/opencensus/BUILD
@@ -1,0 +1,23 @@
+# Copyright 2018, OpenCensus Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+licenses(["notice"])  # Apache 2.0
+
+config_setting(
+    name = "llvm_compiler",
+    values = {
+        "compiler": "llvm",
+    },
+    visibility = [":__subpackages__"],
+)

--- a/opencensus/common/internal/BUILD
+++ b/opencensus/common/internal/BUILD
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("//opencensus:copts.bzl", "DEFAULT_COPTS", "TEST_COPTS")
+
 licenses(["notice"])  # Apache 2.0
 
 package(default_visibility = ["//opencensus:__subpackages__"])
@@ -21,6 +23,7 @@ package(default_visibility = ["//opencensus:__subpackages__"])
 cc_library(
     name = "random_lib",
     srcs = ["random.cc"],
+    copts = DEFAULT_COPTS,
     hdrs = ["random.h"],
     deps = [
         "@com_google_absl//absl/synchronization",
@@ -31,6 +34,7 @@ cc_library(
 cc_library(
     name = "stats_object",
     hdrs = ["stats_object.h"],
+    copts = DEFAULT_COPTS,
     deps = [
         "@com_google_absl//absl/base:core_headers",
         "@com_google_absl//absl/memory",
@@ -43,6 +47,7 @@ cc_library(
 cc_library(
     name = "string_vector_hash",
     hdrs = ["string_vector_hash.h"],
+    copts = DEFAULT_COPTS,
 )
 
 # Tests
@@ -51,6 +56,7 @@ cc_library(
 cc_test(
     name = "random_test",
     srcs = ["random_test.cc"],
+    copts = TEST_COPTS,
     deps = [
         ":random_lib",
         "@com_google_googletest//:gtest_main",
@@ -61,6 +67,7 @@ cc_binary(
     name = "random_benchmark",
     testonly = 1,
     srcs = ["random_benchmark.cc"],
+    copts = TEST_COPTS,
     linkopts = ["-pthread"],  # Required for absl/synchronization bits.
     linkstatic = 1,
     deps = [
@@ -72,6 +79,7 @@ cc_binary(
 cc_test(
     name = "stats_object_test",
     srcs = ["stats_object_test.cc"],
+    copts = TEST_COPTS,
     deps = [
         ":stats_object",
         "@com_google_absl//absl/strings",

--- a/opencensus/copts.bzl
+++ b/opencensus/copts.bzl
@@ -1,0 +1,40 @@
+# Copyright 2018, OpenCensus Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Compiler options for OpenCensus.
+
+Flags specified here must not impact ABI. Code compiled with and without these
+opts will be linked together, and in some cases headers compiled with and
+without these options will be part of the same program.
+
+We use the same flags as absl.
+"""
+
+load(
+    "@com_google_absl//absl:copts.bzl",
+    "GCC_FLAGS",
+    "GCC_TEST_FLAGS",
+    "LLVM_FLAGS",
+    "LLVM_TEST_FLAGS",
+)
+
+DEFAULT_COPTS = select({
+    "//opencensus:llvm_compiler": LLVM_FLAGS,
+    "//conditions:default": GCC_FLAGS,
+})
+
+TEST_COPTS = DEFAULT_COPTS + select({
+    "//opencensus:llvm_compiler": LLVM_TEST_FLAGS,
+    "//conditions:default": GCC_TEST_FLAGS,
+})

--- a/opencensus/stats/BUILD
+++ b/opencensus/stats/BUILD
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("//opencensus:copts.bzl", "DEFAULT_COPTS", "TEST_COPTS")
+
 licenses(["notice"])  # Apache License 2.0
 
 package(default_visibility = ["//visibility:private"])
@@ -22,6 +24,7 @@ package(default_visibility = ["//visibility:private"])
 cc_library(
     name = "stats",
     hdrs = ["stats.h"],
+    copts = DEFAULT_COPTS,
     visibility = ["//visibility:public"],
     deps = [
         ":core",
@@ -36,6 +39,7 @@ cc_library(
     testonly = 1,
     srcs = ["testing/test_utils.cc"],
     hdrs = ["testing/test_utils.h"],
+    copts = DEFAULT_COPTS,
     visibility = ["//visibility:public"],
     deps = [
         ":core",
@@ -74,6 +78,7 @@ cc_library(
         "view_data.h",
         "view_descriptor.h",
     ],
+    copts = DEFAULT_COPTS,
     deps = [
         "@com_google_absl//absl/base:core_headers",
         "@com_google_absl//absl/memory",
@@ -91,6 +96,7 @@ cc_library(
     name = "recording",
     srcs = ["internal/recording.cc"],
     hdrs = ["recording.h"],
+    copts = DEFAULT_COPTS,
     deps = [
         ":core",
         "@com_google_absl//absl/strings",
@@ -107,6 +113,7 @@ cc_library(
         "stats_exporter.h",
         "view.h",
     ],
+    copts = DEFAULT_COPTS,
     deps = [
         ":core",
         "@com_google_absl//absl/base:core_headers",
@@ -123,6 +130,7 @@ cc_library(
 cc_test(
     name = "debug_string_test",
     srcs = ["internal/debug_string_test.cc"],
+    copts = TEST_COPTS,
     deps = [
         ":core",
         "@com_google_absl//absl/time",
@@ -133,6 +141,7 @@ cc_test(
 cc_test(
     name = "distribution_test",
     srcs = ["internal/distribution_test.cc"],
+    copts = TEST_COPTS,
     deps = [
         ":core",
         "@com_google_googletest//:gtest_main",
@@ -142,6 +151,7 @@ cc_test(
 cc_test(
     name = "bucket_boundaries_test",
     srcs = ["internal/bucket_boundaries_test.cc"],
+    copts = TEST_COPTS,
     deps = [
         ":core",
         "@com_google_googletest//:gtest_main",
@@ -151,6 +161,7 @@ cc_test(
 cc_test(
     name = "measure_registry_test",
     srcs = ["internal/measure_registry_test.cc"],
+    copts = TEST_COPTS,
     deps = [
         ":core",
         "@com_google_absl//absl/strings",
@@ -161,6 +172,7 @@ cc_test(
 cc_test(
     name = "stats_exporter_test",
     srcs = ["internal/stats_exporter_test.cc"],
+    copts = TEST_COPTS,
     deps = [
         ":core",
         ":export",
@@ -173,6 +185,7 @@ cc_test(
 cc_test(
     name = "stats_manager_test",
     srcs = ["internal/stats_manager_test.cc"],
+    copts = TEST_COPTS,
     deps = [
         ":core",
         ":export",
@@ -185,6 +198,7 @@ cc_test(
 cc_test(
     name = "view_data_impl_test",
     srcs = ["internal/view_data_impl_test.cc"],
+    copts = TEST_COPTS,
     deps = [
         ":core",
         "@com_google_absl//absl/time",

--- a/opencensus/stats/examples/BUILD
+++ b/opencensus/stats/examples/BUILD
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("//opencensus:copts.bzl", "TEST_COPTS")
+
 licenses(["notice"])  # Apache 2.0
 
 package(
@@ -27,6 +29,7 @@ package(
 cc_test(
     name = "view_and_recording_example",
     srcs = ["view_and_recording_example.cc"],
+    copts = TEST_COPTS,
     deps = [
         "//opencensus/stats",
         "@com_google_googletest//:gtest_main",
@@ -36,6 +39,7 @@ cc_test(
 cc_test(
     name = "exporter_example",
     srcs = ["exporter_example.cc"],
+    copts = TEST_COPTS,
     deps = [
         "@com_google_absl//absl/memory",
         "@com_google_absl//absl/strings",

--- a/opencensus/stats/measure_descriptor.h
+++ b/opencensus/stats/measure_descriptor.h
@@ -36,7 +36,7 @@ class MeasureDescriptor final {
   const std::string& name() const { return name_; }
   const std::string& units() const { return units_; }
   const std::string& description() const { return description_; }
-  const Type type() const { return type_; }
+  Type type() const { return type_; }
 
   std::string DebugString() const;
 

--- a/opencensus/trace/BUILD
+++ b/opencensus/trace/BUILD
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("//opencensus:copts.bzl", "DEFAULT_COPTS", "TEST_COPTS")
+
 licenses(["notice"])  # Apache 2.0
 
 package(default_visibility = ["//visibility:private"])
@@ -76,6 +78,7 @@ cc_library(
         "trace_options.h",
         "trace_params.h",
     ],
+    copts = DEFAULT_COPTS,
     visibility = ["//visibility:public"],
     deps = [
         "@com_google_absl//absl/base:core_headers",
@@ -94,6 +97,7 @@ cc_library(
 cc_test(
     name = "annotation_test",
     srcs = ["internal/annotation_test.cc"],
+    copts = TEST_COPTS,
     deps = [
         ":trace",
         "@com_google_absl//absl/strings",
@@ -104,6 +108,7 @@ cc_test(
 cc_test(
     name = "attribute_value_ref_test",
     srcs = ["internal/attribute_value_ref_test.cc"],
+    copts = TEST_COPTS,
     deps = [
         ":trace",
         "@com_google_absl//absl/strings",
@@ -114,6 +119,7 @@ cc_test(
 cc_test(
     name = "attribute_value_test",
     srcs = ["internal/attribute_value_test.cc"],
+    copts = TEST_COPTS,
     deps = [
         ":trace",
         "@com_google_absl//absl/strings",
@@ -124,6 +130,7 @@ cc_test(
 cc_test(
     name = "link_test",
     srcs = ["internal/link_test.cc"],
+    copts = TEST_COPTS,
     deps = [
         ":trace",
         "@com_google_googletest//:gtest_main",
@@ -133,6 +140,7 @@ cc_test(
 cc_test(
     name = "local_span_store_test",
     srcs = ["internal/local_span_store_test.cc"],
+    copts = TEST_COPTS,
     deps = [
         ":trace",
         "@com_google_absl//absl/memory",
@@ -144,6 +152,7 @@ cc_test(
 cc_test(
     name = "running_span_store_test",
     srcs = ["internal/running_span_store_test.cc"],
+    copts = TEST_COPTS,
     deps = [
         ":trace",
         "@com_google_absl//absl/memory",
@@ -155,6 +164,7 @@ cc_test(
 cc_test(
     name = "sampler_test",
     srcs = ["internal/sampler_test.cc"],
+    copts = TEST_COPTS,
     deps = [
         ":trace",
         "@com_google_absl//absl/strings",
@@ -167,6 +177,7 @@ cc_test(
 cc_test(
     name = "span_test",
     srcs = ["internal/span_test.cc"],
+    copts = TEST_COPTS,
     deps = [
         ":trace",
         "@com_google_absl//absl/synchronization",
@@ -177,6 +188,7 @@ cc_test(
 cc_test(
     name = "span_id_test",
     srcs = ["internal/span_id_test.cc"],
+    copts = TEST_COPTS,
     deps = [
         ":trace",
         "@com_google_googletest//:gtest_main",
@@ -186,6 +198,7 @@ cc_test(
 cc_test(
     name = "span_options_test",
     srcs = ["internal/span_options_test.cc"],
+    copts = TEST_COPTS,
     deps = [
         ":trace",
         "@com_google_absl//absl/strings",
@@ -197,6 +210,7 @@ cc_test(
 cc_test(
     name = "span_context_test",
     srcs = ["internal/span_context_test.cc"],
+    copts = TEST_COPTS,
     deps = [
         ":trace",
         "@com_google_absl//absl/strings",
@@ -208,6 +222,7 @@ cc_test(
 cc_test(
     name = "span_exporter_test",
     srcs = ["internal/span_exporter_test.cc"],
+    copts = TEST_COPTS,
     deps = [
         ":trace",
         "@com_google_absl//absl/memory",
@@ -221,6 +236,7 @@ cc_test(
 cc_test(
     name = "status_test",
     srcs = ["internal/status_test.cc"],
+    copts = TEST_COPTS,
     deps = [
         ":trace",
         "@com_google_absl//absl/strings",
@@ -231,6 +247,7 @@ cc_test(
 cc_test(
     name = "trace_config_test",
     srcs = ["internal/trace_config_test.cc"],
+    copts = TEST_COPTS,
     deps = [
         ":trace",
         "@com_google_absl//absl/time",
@@ -241,6 +258,7 @@ cc_test(
 cc_test(
     name = "trace_options_test",
     srcs = ["internal/trace_options_test.cc"],
+    copts = TEST_COPTS,
     deps = [
         ":trace",
         "@com_google_googletest//:gtest_main",
@@ -254,6 +272,7 @@ cc_binary(
     name = "span_benchmark",
     testonly = 1,
     srcs = ["internal/span_benchmark.cc"],
+    copts = TEST_COPTS,
     linkopts = ["-pthread"],  # Required for absl/synchronization bits.
     linkstatic = 1,
     deps = [
@@ -266,6 +285,7 @@ cc_binary(
     name = "span_id_benchmark",
     testonly = 1,
     srcs = ["internal/span_id_benchmark.cc"],
+    copts = TEST_COPTS,
     linkopts = ["-pthread"],  # Required for absl/synchronization bits.
     linkstatic = 1,
     deps = [

--- a/opencensus/trace/examples/BUILD
+++ b/opencensus/trace/examples/BUILD
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("//opencensus:copts.bzl", "TEST_COPTS")
+
 licenses(["notice"])  # Apache 2.0
 
 package(
@@ -27,6 +29,7 @@ package(
 cc_test(
     name = "span_example",
     srcs = ["span_example.cc"],
+    copts = TEST_COPTS,
     deps = [
         "@com_google_absl//absl/memory",
         "@com_google_absl//absl/strings",

--- a/opencensus/trace/internal/sampler.cc
+++ b/opencensus/trace/internal/sampler.cc
@@ -17,6 +17,8 @@
 #include <cmath>
 #include <cstdint>
 
+#include "absl/base/attributes.h"
+
 namespace opencensus {
 namespace trace {
 
@@ -52,9 +54,11 @@ ProbabilitySampler::ProbabilitySampler(double probability)
     : threshold_(CalculateThreshold(probability)) {}
 
 bool ProbabilitySampler::ShouldSample(
-    const SpanContext* parent_context, bool has_remote_parent,
-    const TraceId& trace_id, const SpanId& span_id, absl::string_view name,
-    const std::vector<Span*>& parent_links) const {
+    const SpanContext* parent_context ABSL_ATTRIBUTE_UNUSED,
+    bool has_remote_parent ABSL_ATTRIBUTE_UNUSED, const TraceId& trace_id,
+    const SpanId& span_id ABSL_ATTRIBUTE_UNUSED,
+    absl::string_view name ABSL_ATTRIBUTE_UNUSED,
+    const std::vector<Span*>& parent_links ABSL_ATTRIBUTE_UNUSED) const {
   if (threshold_ == 0) return false;
   // All Spans within the same Trace will get the same sampling decision, so
   // full trees of Spans will be sampled.

--- a/opencensus/trace/sampler.h
+++ b/opencensus/trace/sampler.h
@@ -18,6 +18,7 @@
 #include <cstdint>
 #include <vector>
 
+#include "absl/base/attributes.h"
 #include "absl/strings/string_view.h"
 #include "opencensus/trace/span_context.h"
 #include "opencensus/trace/span_id.h"
@@ -67,10 +68,13 @@ class ProbabilitySampler final : public Sampler {
 // Always samples.
 class AlwaysSampler final : public Sampler {
  public:
-  bool ShouldSample(const SpanContext* parent_context, bool has_remote_parent,
-                    const TraceId& trace_id, const SpanId& span_id,
-                    absl::string_view name,
-                    const std::vector<Span*>& parent_links) const override {
+  bool ShouldSample(const SpanContext* parent_context ABSL_ATTRIBUTE_UNUSED,
+                    bool has_remote_parent ABSL_ATTRIBUTE_UNUSED,
+                    const TraceId& trace_id ABSL_ATTRIBUTE_UNUSED,
+                    const SpanId& span_id ABSL_ATTRIBUTE_UNUSED,
+                    absl::string_view name ABSL_ATTRIBUTE_UNUSED,
+                    const std::vector<Span*>& parent_links
+                        ABSL_ATTRIBUTE_UNUSED) const override {
     return true;
   }
 };
@@ -78,10 +82,13 @@ class AlwaysSampler final : public Sampler {
 // Never samples.
 class NeverSampler final : public Sampler {
  public:
-  bool ShouldSample(const SpanContext* parent_context, bool has_remote_parent,
-                    const TraceId& trace_id, const SpanId& span_id,
-                    absl::string_view name,
-                    const std::vector<Span*>& parent_links) const override {
+  bool ShouldSample(const SpanContext* parent_context ABSL_ATTRIBUTE_UNUSED,
+                    bool has_remote_parent ABSL_ATTRIBUTE_UNUSED,
+                    const TraceId& trace_id ABSL_ATTRIBUTE_UNUSED,
+                    const SpanId& span_id ABSL_ATTRIBUTE_UNUSED,
+                    absl::string_view name ABSL_ATTRIBUTE_UNUSED,
+                    const std::vector<Span*>& parent_links
+                        ABSL_ATTRIBUTE_UNUSED) const override {
     return false;
   }
 };


### PR DESCRIPTION
In particular, -Wno-sign-compare as Google style does not use unsigned
integers.