### PR TITLE
Add a test-only library granting access to the ViewData constructor.

### DIFF
--- a/opencensus/stats/BUILD
+++ b/opencensus/stats/BUILD
@@ -30,6 +30,20 @@ cc_library(
     ],
 )
 
+# Test-only utilities.
+cc_library(
+    name = "test_utils",
+    testonly = 1,
+    srcs = ["testing/test_utils.cc"],
+    hdrs = ["testing/test_utils.h"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":core",
+        "@com_google_absl//absl/memory",
+        "@com_google_absl//absl/time",
+    ],
+)
+
 cc_library(
     name = "core",
     srcs = [

--- a/opencensus/stats/examples/exporter_example.cc
+++ b/opencensus/stats/examples/exporter_example.cc
@@ -102,14 +102,13 @@ TEST_F(ExporterExample, Distribution) {
       opencensus::stats::ViewDescriptor()
           .set_name("example.com/Bar/FooUsage-sum-interval-foo_id")
           .set_measure(kFooUsageMeasureName)
-          .set_name("example.com/Bar/FooUsage-sum-delta-foo_id")
           .set_aggregation(opencensus::stats::Aggregation::Sum())
           .set_aggregation_window(
               opencensus::stats::AggregationWindow::Interval(absl::Hours(1)))
           .add_column("foo_id")
           .set_description(
-              "Cumulative sum of example.com/Foo/FooUsage broken down "
-              "by 'foo_id'.");
+              "Rolling sum of example.com/Foo/FooUsage over the previous hour "
+              "broken down by 'foo_id'.");
 
   // The order of view registration and exporter creation does not matter, as
   // long as both precede data recording.

--- a/opencensus/stats/testing/test_utils.cc
+++ b/opencensus/stats/testing/test_utils.cc
@@ -1,0 +1,39 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "opencensus/stats/testing/test_utils.h"
+
+#include <memory>
+
+#include "absl/memory/memory.h"
+#include "absl/time/time.h"
+
+namespace opencensus {
+namespace stats {
+namespace testing {
+
+// static
+ViewData TestUtils::MakeViewData(
+    const ViewDescriptor& descriptor,
+    std::initializer_list<std::pair<std::vector<std::string>, double>> values) {
+  auto impl = absl::make_unique<ViewDataImpl>(absl::UnixEpoch(), descriptor);
+  for (const auto& value : values) {
+    impl->Add(value.second, value.first, absl::UnixEpoch());
+  }
+  return ViewData(std::move(impl));
+}
+
+}  // namespace testing
+}  // namespace stats
+}  // namespace opencensus

--- a/opencensus/stats/testing/test_utils.h
+++ b/opencensus/stats/testing/test_utils.h
@@ -1,0 +1,42 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef OPENCENSUS_STATS_TESTING_TEST_UTILS_H_
+#define OPENCENSUS_STATS_TESTING_TEST_UTILS_H_
+
+#include <initializer_list>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "opencensus/stats/internal/view_data_impl.h"
+#include "opencensus/stats/view_data.h"
+
+namespace opencensus {
+namespace stats {
+namespace testing {
+
+class TestUtils final {
+ public:
+  static ViewData MakeViewData(
+      const ViewDescriptor& descriptor,
+      std::initializer_list<std::pair<std::vector<std::string>, double>>
+          values);
+};
+
+}  // namespace testing
+}  // namespace stats
+}  // namespace opencensus
+
+#endif  // OPENCENSUS_STATS_TESTING_TEST_UTILS_H_

--- a/opencensus/stats/view_data.h
+++ b/opencensus/stats/view_data.h
@@ -30,7 +30,11 @@
 namespace opencensus {
 namespace stats {
 
+// Forward declarations of friends.
 class ViewDataImpl;
+namespace testing {
+class TestUtils;
+}
 
 // ViewData is an immutable snapshot of data for a particular View, aggregated
 // according to the View's Aggregation and AggregationWindow.
@@ -69,6 +73,7 @@ class ViewData {
 
  private:
   friend class View;  // Allowed to call the private constructor.
+  friend class testing::TestUtils;
   explicit ViewData(std::unique_ptr<ViewDataImpl> data);
 
   const std::unique_ptr<ViewDataImpl> impl_;


### PR DESCRIPTION
This is needed for testing exporters without using the full View/Record
workflow.