### PR TITLE
Wait and retry checking server stats in the stats_plugin_end2end_test.

### DIFF
--- a/opencensus/plugins/BUILD
+++ b/opencensus/plugins/BUILD
@@ -63,6 +63,7 @@ cc_test(
     timeout = "short",
     srcs = ["internal/stats_plugin_end2end_test.cc"],
     copts = TEST_COPTS,
+    flaky = True,  # RPCs are sometimes lost or retried, messing up stats.
     linkopts = [
         "-pthread",
     ],

--- a/opencensus/plugins/BUILD
+++ b/opencensus/plugins/BUILD
@@ -60,6 +60,7 @@ cc_library(
 
 cc_test(
     name = "stats_plugin_end2end_test",
+    timeout = "short",
     srcs = ["internal/stats_plugin_end2end_test.cc"],
     copts = TEST_COPTS,
     linkopts = [
@@ -71,6 +72,7 @@ cc_test(
         "//opencensus/stats",
         "@com_github_grpc_grpc//:grpc++",
         "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/time",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/opencensus/plugins/internal/stats_plugin_end2end_test.cc
+++ b/opencensus/plugins/internal/stats_plugin_end2end_test.cc
@@ -72,6 +72,14 @@ class StatsPluginEnd2EndTest : public ::testing::Test {
     server_thread_.join();
   }
 
+  // Sets a one-second deadline on a client context.
+  static void SetDeadline(::grpc::ClientContext* context) {
+    gpr_timespec deadline;
+    deadline.clock_type = gpr_clock_type::GPR_TIMESPAN;
+    deadline.tv_sec = 1;
+    context->set_deadline(deadline);
+  }
+
   void RunServerLoop() { server_->Wait(); }
 
   const std::string method_name_ = "/opencensus.testing.EchoService/Echo";

--- a/opencensus/plugins/internal/stats_plugin_end2end_test.cc
+++ b/opencensus/plugins/internal/stats_plugin_end2end_test.cc
@@ -18,6 +18,8 @@
 
 #include "absl/strings/str_cat.h"
 #include "absl/strings/string_view.h"
+#include "absl/time/clock.h"
+#include "absl/time/time.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "include/grpc++/grpc++.h"
@@ -127,6 +129,11 @@ TEST_F(StatsPluginEnd2EndTest, ErrorCount) {
     ::grpc::Status status = stub_->Echo(&context, request, &response);
   }
 
+  // Avoid a possible race condition with the server recording data.
+  while (server_status_view.GetData().double_data().size() < 17) {
+    absl::SleepFor(absl::Milliseconds(100));
+  }
+
   EXPECT_THAT(client_method_view.GetData().double_data(),
               ::testing::UnorderedElementsAre(
                   ::testing::Pair(::testing::ElementsAre(method_name_), 16.0)));
@@ -226,6 +233,10 @@ TEST_F(StatsPluginEnd2EndTest, RequestResponseBytes) {
   EXPECT_EQ(1, client_response_bytes->second.count());
   EXPECT_GT(client_response_bytes->second.mean(), 0);
 
+  // Avoid a possible race condition with the server recording data.
+  while (server_request_bytes_view.GetData().distribution_data().empty()) {
+    absl::SleepFor(absl::Milliseconds(100));
+  }
   const auto server_request_bytes_data =
       server_request_bytes_view.GetData().distribution_data();
   ASSERT_EQ(1, server_request_bytes_data.size());
@@ -313,6 +324,11 @@ TEST_F(StatsPluginEnd2EndTest, Latency) {
   EXPECT_LT(client_server_elapsed_time->second.mean(),
             client_latency->second.mean());
 
+  // Avoid a possible race condition with the server recording data.
+  while (
+      server_server_elapsed_time_view.GetData().distribution_data().empty()) {
+    absl::SleepFor(absl::Milliseconds(100));
+  }
   const auto server_server_elapsed_time_data =
       server_server_elapsed_time_view.GetData().distribution_data();
   ASSERT_EQ(1, server_server_elapsed_time_data.size());
@@ -378,9 +394,19 @@ TEST_F(StatsPluginEnd2EndTest, StartFinishCount) {
     EXPECT_THAT(client_finished_count_view.GetData().double_data(),
                 ::testing::UnorderedElementsAre(::testing::Pair(
                     ::testing::ElementsAre(method_name_), i + 1)));
+
     EXPECT_THAT(server_started_count_view.GetData().double_data(),
                 ::testing::UnorderedElementsAre(::testing::Pair(
                     ::testing::ElementsAre(method_name_), i + 1)));
+    // Avoid a possible race condition with the server recording data. (server
+    // started count is updated before the server replies.)
+    while (server_finished_count_view.GetData().double_data().empty() ||
+           server_finished_count_view.GetData()
+                   .double_data()
+                   .find({method_name_})
+                   ->second != i + 1) {
+      absl::SleepFor(absl::Milliseconds(100));
+    }
     EXPECT_THAT(server_finished_count_view.GetData().double_data(),
                 ::testing::UnorderedElementsAre(::testing::Pair(
                     ::testing::ElementsAre(method_name_), i + 1)));
@@ -440,6 +466,15 @@ TEST_F(StatsPluginEnd2EndTest, RequestResponseCount) {
     EXPECT_THAT(client_response_count_view.GetData().double_data(),
                 ::testing::UnorderedElementsAre(::testing::Pair(
                     ::testing::ElementsAre(method_name_), i + 1)));
+
+    // Avoid a possible race condition with the server recording data.
+    while (server_request_count_view.GetData().double_data().empty() ||
+           server_request_count_view.GetData()
+                   .double_data()
+                   .find({method_name_})
+                   ->second != i + 1) {
+      absl::SleepFor(absl::Milliseconds(100));
+    }
     EXPECT_THAT(server_request_count_view.GetData().double_data(),
                 ::testing::UnorderedElementsAre(::testing::Pair(
                     ::testing::ElementsAre(method_name_), i + 1)));


### PR DESCRIPTION
Server stats are updated by the server thread after the server responds, creating a possible race condition. This commit completely avoids race failures, although still leaves minor (~0.1%) flakiness from RPC failures (see issue #29).