### PR TITLE
Add a "noci" tag for tests that should run locally and build but not run in Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,4 @@ script:
   # We can't use --noshow_progress because Travis terminates the
   # build after 10 mins without output.
   - bazel build --experimental_ui_actions_shown=1 -k $(bazel query ... | grep -v :_)
-  - bazel test --experimental_ui_actions_shown=1 -k $(bazel query ... | grep -v :_)
+  - bazel test --experimental_ui_actions_shown=1 -k $(bazel query "kind(test, //...) except attr('tags', 'noci', //...)" | grep -v :_)

--- a/opencensus/plugins/BUILD
+++ b/opencensus/plugins/BUILD
@@ -62,9 +62,11 @@ cc_test(
     name = "stats_plugin_end2end_test",
     srcs = ["internal/stats_plugin_end2end_test.cc"],
     copts = TEST_COPTS,
+    flaky = True,  # RPCs are unreliable.
     linkopts = [
         "-pthread",
     ],
+    tags = ["noci"],  # TODO: determine why this times out on Travis and reenable.
     deps = [
         ":grpc_plugin",
         "//opencensus/plugins/internal/testing:echo_proto",

--- a/opencensus/stats/examples/BUILD
+++ b/opencensus/stats/examples/BUILD
@@ -40,11 +40,12 @@ cc_test(
     name = "exporter_example",
     srcs = ["exporter_example.cc"],
     copts = TEST_COPTS,
+    tags = ["noci"],  # This runs slowly and is not very useful as a test.
     deps = [
+        "//opencensus/stats",
         "@com_google_absl//absl/memory",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/time",
-        "//opencensus/stats",
         "@com_google_googletest//:gtest_main",
     ],
 )


### PR DESCRIPTION
A more aggressive fix for #29.

stats_plugin_end2end_test is minorly flaky locally but times out with very high probability in Travis, seemingly due to local-port issues--I hope to fix it eventually but blacklisting it seems the best solution for now.

exporter_example runs very slowly due to sleeps and does not provide value as a test.