### PR TITLE
Depend on gRPC master branch.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -38,11 +38,8 @@ http_archive(
 # gRPC
 http_archive(
     name = "com_github_grpc_grpc",
-    # TODO: Switch to master branch:
-    #urls = ["https://github.com/grpc/grpc/archive/master.zip"],
-    #strip_prefix = "grpc-master"
-    urls = ["https://github.com/grpc/grpc/archive/v1.9.1.zip"],
-    strip_prefix = "grpc-1.9.1",
+    urls = ["https://github.com/grpc/grpc/archive/master.tar.gz"],
+    strip_prefix = "grpc-master"
 )
 
 load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")


### PR DESCRIPTION
Using *.tar.gz instead of *.zip works around:
https://github.com/bazelbuild/bazel/issues/2656