### PR TITLE
Record the present time once in Record() and pass that value to ViewInformation::Record().

### DIFF
--- a/opencensus/stats/BUILD
+++ b/opencensus/stats/BUILD
@@ -105,6 +105,7 @@ cc_library(
     deps = [
         ":core",
         "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/time",
     ],
 )
 

--- a/opencensus/stats/internal/recording.cc
+++ b/opencensus/stats/internal/recording.cc
@@ -14,6 +14,7 @@
 
 #include "opencensus/stats/recording.h"
 
+#include "absl/time/clock.h"
 #include "opencensus/stats/internal/stats_manager.h"
 #include "opencensus/stats/measure.h"
 
@@ -24,7 +25,7 @@ void Record(
     std::initializer_list<Measurement> measurements,
     std::initializer_list<std::pair<absl::string_view, absl::string_view>>
         tags) {
-  StatsManager::Get()->Record(measurements, tags);
+  StatsManager::Get()->Record(measurements, tags, absl::Now());
 }
 
 }  // namespace stats


### PR DESCRIPTION
absl::Now() is remarkably expensive, and calling it for each ViewData was responsible for 6-8% of time spent in batched recording--after these changes total time in absl::Now() is negligible. (Log recording would move this off the critical path, but this would still help during log harvesting.)