### PR TITLE
Remove AggregationWindow from the public API.

### DIFF
--- a/opencensus/exporters/stats/e2e/stackdriver_e2e_test.cc
+++ b/opencensus/exporters/stats/e2e/stackdriver_e2e_test.cc
@@ -161,8 +161,6 @@ TEST_F(StackdriverE2eTest, OneView) {
               prefix_))
           .set_measure(kTestMeasureName)
           .set_aggregation(::opencensus::stats::Aggregation::Sum())
-          .set_aggregation_window(
-              ::opencensus::stats::AggregationWindow::Cumulative())
           .add_column("key1")
           .add_column("key2")
           .set_description(
@@ -199,8 +197,6 @@ TEST_F(StackdriverE2eTest, LargeTest) {
               prefix_))
           .set_measure(kTestMeasureName)
           .set_aggregation(::opencensus::stats::Aggregation::Count())
-          .set_aggregation_window(
-              ::opencensus::stats::AggregationWindow::Cumulative())
           .add_column("key1")
           .add_column("key2")
           .set_description(
@@ -215,8 +211,6 @@ TEST_F(StackdriverE2eTest, LargeTest) {
               prefix_))
           .set_measure(kTestMeasureName)
           .set_aggregation(::opencensus::stats::Aggregation::Sum())
-          .set_aggregation_window(
-              ::opencensus::stats::AggregationWindow::Cumulative())
           .add_column("key1")
           .add_column("key2")
           .set_description(

--- a/opencensus/exporters/stats/internal/stackdriver_utils_test.cc
+++ b/opencensus/exporters/stats/internal/stackdriver_utils_test.cc
@@ -77,8 +77,6 @@ TEST(StackdriverUtilsTest, SetMetricDescriptorMetricKind) {
   auto view_descriptor = opencensus::stats::ViewDescriptor();
   google::api::MetricDescriptor metric_descriptor;
 
-  view_descriptor.set_aggregation_window(
-      opencensus::stats::AggregationWindow::Cumulative());
   SetMetricDescriptor("", view_descriptor, &metric_descriptor);
   EXPECT_EQ(google::api::MetricDescriptor::CUMULATIVE,
             metric_descriptor.metric_kind());
@@ -157,8 +155,6 @@ TEST(StackdriverUtilsTest, MakeTimeSeriesSumDouble) {
           .set_name(view_name)
           .set_measure(measure.GetDescriptor().name())
           .set_aggregation(opencensus::stats::Aggregation::Sum())
-          .set_aggregation_window(
-              opencensus::stats::AggregationWindow::Cumulative())
           .add_column(tag_key_1)
           .add_column(tag_key_2);
   const opencensus::stats::ViewData data = TestUtils::MakeViewData(
@@ -199,8 +195,6 @@ TEST(StackdriverUtilsTest, MakeTimeSeriesSumInt) {
           .set_name(view_name)
           .set_measure(measure.GetDescriptor().name())
           .set_aggregation(opencensus::stats::Aggregation::Sum())
-          .set_aggregation_window(
-              opencensus::stats::AggregationWindow::Cumulative())
           .add_column(tag_key_1)
           .add_column(tag_key_2);
   const opencensus::stats::ViewData data = TestUtils::MakeViewData(
@@ -242,8 +236,6 @@ TEST(StackdriverUtilsTest, MakeTimeSeriesCountDouble) {
           .set_name(view_name)
           .set_measure(measure.GetDescriptor().name())
           .set_aggregation(opencensus::stats::Aggregation::Count())
-          .set_aggregation_window(
-              opencensus::stats::AggregationWindow::Cumulative())
           .add_column(tag_key_1)
           .add_column(tag_key_2);
   const opencensus::stats::ViewData data = TestUtils::MakeViewData(
@@ -289,8 +281,6 @@ TEST(StackdriverUtilsTest, MakeTimeSeriesDistributionDouble) {
           .set_measure(measure.GetDescriptor().name())
           .set_aggregation(
               opencensus::stats::Aggregation::Distribution(bucket_boundaries))
-          .set_aggregation_window(
-              opencensus::stats::AggregationWindow::Cumulative())
           .add_column(tag_key_1)
           .add_column(tag_key_2);
   const opencensus::stats::ViewData data = TestUtils::MakeViewData(

--- a/opencensus/plugins/internal/stats_plugin_end2end_test.cc
+++ b/opencensus/plugins/internal/stats_plugin_end2end_test.cc
@@ -88,7 +88,7 @@ TEST_F(StatsPluginEnd2EndTest, ErrorCount) {
           .set_measure(kRpcClientErrorCountMeasureName)
           .set_name("client_method")
           .set_aggregation(stats::Aggregation::Sum())
-          .set_aggregation_window(stats::AggregationWindow::Cumulative())
+
           .add_column(kMethodTagKey);
   stats::View client_method_view(client_method_descriptor);
   const auto server_method_descriptor =
@@ -96,7 +96,6 @@ TEST_F(StatsPluginEnd2EndTest, ErrorCount) {
           .set_measure(kRpcServerErrorCountMeasureName)
           .set_name("server_method")
           .set_aggregation(stats::Aggregation::Sum())
-          .set_aggregation_window(stats::AggregationWindow::Cumulative())
           .add_column(kMethodTagKey);
   stats::View server_method_view(client_method_descriptor);
 
@@ -105,7 +104,6 @@ TEST_F(StatsPluginEnd2EndTest, ErrorCount) {
           .set_measure(kRpcClientErrorCountMeasureName)
           .set_name("client_status")
           .set_aggregation(stats::Aggregation::Sum())
-          .set_aggregation_window(stats::AggregationWindow::Cumulative())
           .add_column(kStatusTagKey);
   stats::View client_status_view(client_status_descriptor);
   const auto server_status_descriptor =
@@ -113,7 +111,6 @@ TEST_F(StatsPluginEnd2EndTest, ErrorCount) {
           .set_measure(kRpcServerErrorCountMeasureName)
           .set_name("server_status")
           .set_aggregation(stats::Aggregation::Sum())
-          .set_aggregation_window(stats::AggregationWindow::Cumulative())
           .add_column(kStatusTagKey);
   stats::View server_status_view(server_status_descriptor);
 
@@ -167,7 +164,6 @@ TEST_F(StatsPluginEnd2EndTest, RequestResponseBytes) {
           .set_name("client_request_bytes")
           .set_aggregation(stats::Aggregation::Distribution(
               stats::BucketBoundaries::Explicit({})))
-          .set_aggregation_window(stats::AggregationWindow::Cumulative())
           .add_column(kMethodTagKey);
   stats::View client_request_bytes_view(client_request_bytes_descriptor);
   const auto client_response_bytes_descriptor =
@@ -176,7 +172,6 @@ TEST_F(StatsPluginEnd2EndTest, RequestResponseBytes) {
           .set_name("client_response_bytes")
           .set_aggregation(stats::Aggregation::Distribution(
               stats::BucketBoundaries::Explicit({})))
-          .set_aggregation_window(stats::AggregationWindow::Cumulative())
           .add_column(kMethodTagKey);
   stats::View client_response_bytes_view(client_response_bytes_descriptor);
   const auto server_request_bytes_descriptor =
@@ -185,7 +180,6 @@ TEST_F(StatsPluginEnd2EndTest, RequestResponseBytes) {
           .set_name("server_request_bytes")
           .set_aggregation(stats::Aggregation::Distribution(
               stats::BucketBoundaries::Explicit({})))
-          .set_aggregation_window(stats::AggregationWindow::Cumulative())
           .add_column(kMethodTagKey);
   stats::View server_request_bytes_view(server_request_bytes_descriptor);
   const auto server_response_bytes_descriptor =
@@ -194,7 +188,6 @@ TEST_F(StatsPluginEnd2EndTest, RequestResponseBytes) {
           .set_name("server_response_bytes")
           .set_aggregation(stats::Aggregation::Distribution(
               stats::BucketBoundaries::Explicit({})))
-          .set_aggregation_window(stats::AggregationWindow::Cumulative())
           .add_column(kMethodTagKey);
   stats::View server_response_bytes_view(server_response_bytes_descriptor);
 
@@ -254,7 +247,6 @@ TEST_F(StatsPluginEnd2EndTest, Latency) {
           .set_name("client_latency")
           .set_aggregation(stats::Aggregation::Distribution(
               stats::BucketBoundaries::Explicit({})))
-          .set_aggregation_window(stats::AggregationWindow::Cumulative())
           .add_column(kMethodTagKey);
   stats::View client_latency_view(client_latency_descriptor);
   const auto client_server_elapsed_time_descriptor =
@@ -263,7 +255,6 @@ TEST_F(StatsPluginEnd2EndTest, Latency) {
           .set_name("client_server_elapsed_time")
           .set_aggregation(stats::Aggregation::Distribution(
               stats::BucketBoundaries::Explicit({})))
-          .set_aggregation_window(stats::AggregationWindow::Cumulative())
           .add_column(kMethodTagKey);
   stats::View client_server_elapsed_time_view(
       client_server_elapsed_time_descriptor);
@@ -273,7 +264,6 @@ TEST_F(StatsPluginEnd2EndTest, Latency) {
           .set_name("server_server_elapsed_time")
           .set_aggregation(stats::Aggregation::Distribution(
               stats::BucketBoundaries::Explicit({})))
-          .set_aggregation_window(stats::AggregationWindow::Cumulative())
           .add_column(kMethodTagKey);
   stats::View server_server_elapsed_time_view(
       server_server_elapsed_time_descriptor);
@@ -332,7 +322,6 @@ TEST_F(StatsPluginEnd2EndTest, StartFinishCount) {
           .set_measure(kRpcClientStartedCountMeasureName)
           .set_name("client_started_count")
           .set_aggregation(stats::Aggregation::Sum())
-          .set_aggregation_window(stats::AggregationWindow::Cumulative())
           .add_column(kMethodTagKey);
   stats::View client_started_count_view(client_started_count_descriptor);
   const auto client_finished_count_descriptor =
@@ -340,7 +329,6 @@ TEST_F(StatsPluginEnd2EndTest, StartFinishCount) {
           .set_measure(kRpcClientFinishedCountMeasureName)
           .set_name("client_finished_count")
           .set_aggregation(stats::Aggregation::Sum())
-          .set_aggregation_window(stats::AggregationWindow::Cumulative())
           .add_column(kMethodTagKey);
   stats::View client_finished_count_view(client_finished_count_descriptor);
   const auto server_started_count_descriptor =
@@ -348,7 +336,6 @@ TEST_F(StatsPluginEnd2EndTest, StartFinishCount) {
           .set_measure(kRpcServerStartedCountMeasureName)
           .set_name("server_started_count")
           .set_aggregation(stats::Aggregation::Sum())
-          .set_aggregation_window(stats::AggregationWindow::Cumulative())
           .add_column(kMethodTagKey);
   stats::View server_started_count_view(server_started_count_descriptor);
   const auto server_finished_count_descriptor =
@@ -356,7 +343,6 @@ TEST_F(StatsPluginEnd2EndTest, StartFinishCount) {
           .set_measure(kRpcServerFinishedCountMeasureName)
           .set_name("server_finished_count")
           .set_aggregation(stats::Aggregation::Sum())
-          .set_aggregation_window(stats::AggregationWindow::Cumulative())
           .add_column(kMethodTagKey);
   stats::View server_finished_count_view(server_finished_count_descriptor);
 
@@ -394,7 +380,6 @@ TEST_F(StatsPluginEnd2EndTest, RequestResponseCount) {
           .set_measure(kRpcClientRequestCountMeasureName)
           .set_name("client_request_count")
           .set_aggregation(stats::Aggregation::Sum())
-          .set_aggregation_window(stats::AggregationWindow::Cumulative())
           .add_column(kMethodTagKey);
   stats::View client_request_count_view(client_request_count_descriptor);
   const auto client_response_count_descriptor =
@@ -402,7 +387,6 @@ TEST_F(StatsPluginEnd2EndTest, RequestResponseCount) {
           .set_measure(kRpcClientResponseCountMeasureName)
           .set_name("client_response_count")
           .set_aggregation(stats::Aggregation::Sum())
-          .set_aggregation_window(stats::AggregationWindow::Cumulative())
           .add_column(kMethodTagKey);
   stats::View client_response_count_view(client_response_count_descriptor);
   const auto server_request_count_descriptor =
@@ -410,7 +394,6 @@ TEST_F(StatsPluginEnd2EndTest, RequestResponseCount) {
           .set_measure(kRpcServerRequestCountMeasureName)
           .set_name("server_request_count")
           .set_aggregation(stats::Aggregation::Sum())
-          .set_aggregation_window(stats::AggregationWindow::Cumulative())
           .add_column(kMethodTagKey);
   stats::View server_request_count_view(server_request_count_descriptor);
   const auto server_response_count_descriptor =
@@ -418,7 +401,6 @@ TEST_F(StatsPluginEnd2EndTest, RequestResponseCount) {
           .set_measure(kRpcServerResponseCountMeasureName)
           .set_name("server_response_count")
           .set_aggregation(stats::Aggregation::Sum())
-          .set_aggregation_window(stats::AggregationWindow::Cumulative())
           .add_column(kMethodTagKey);
   stats::View server_response_count_view(server_response_count_descriptor);
 

--- a/opencensus/stats/BUILD
+++ b/opencensus/stats/BUILD
@@ -23,7 +23,10 @@ package(default_visibility = ["//visibility:private"])
 # The public stats API.
 cc_library(
     name = "stats",
-    hdrs = ["stats.h"],
+    hdrs = [
+        "internal/set_aggregation_window.h",
+        "stats.h",
+    ],
     copts = DEFAULT_COPTS,
     visibility = ["//visibility:public"],
     deps = [
@@ -59,6 +62,7 @@ cc_library(
         "internal/measure_descriptor.cc",
         "internal/measure_registry.cc",
         "internal/measure_registry_impl.cc",
+        "internal/set_aggregation_window.cc",
         "internal/stats_manager.cc",
         "internal/view_data.cc",
         "internal/view_data_impl.cc",
@@ -66,10 +70,11 @@ cc_library(
     ],
     hdrs = [
         "aggregation.h",
-        "aggregation_window.h",
         "bucket_boundaries.h",
         "distribution.h",
+        "internal/aggregation_window.h",
         "internal/measure_registry_impl.h",
+        "internal/set_aggregation_window.h",
         "internal/stats_manager.h",
         "internal/view_data_impl.h",
         "measure.h",
@@ -80,6 +85,8 @@ cc_library(
     ],
     copts = DEFAULT_COPTS,
     deps = [
+        "//opencensus/common/internal:stats_object",
+        "//opencensus/common/internal:string_vector_hash",
         "@com_google_absl//absl/base:core_headers",
         "@com_google_absl//absl/memory",
         "@com_google_absl//absl/strings",
@@ -87,8 +94,6 @@ cc_library(
         "@com_google_absl//absl/time",
         "@com_google_absl//absl/types:optional",
         "@com_google_absl//absl/types:span",
-        "//opencensus/common/internal:stats_object",
-        "//opencensus/common/internal:string_vector_hash",
     ],
 )
 

--- a/opencensus/stats/examples/exporter_example.cc
+++ b/opencensus/stats/examples/exporter_example.cc
@@ -77,34 +77,30 @@ TEST_F(ExporterExample, Distribution) {
   SetupFoo();
 
   // The stats consumer creates a View on Foo Usage.
-  const auto cumulative_descriptor =
+  const auto sum_descriptor =
       opencensus::stats::ViewDescriptor()
           .set_name("example.com/Bar/FooUsage-sum-cumulative-foo_id")
           .set_measure(kFooUsageMeasureName)
           .set_aggregation(opencensus::stats::Aggregation::Sum())
-          .set_aggregation_window(
-              opencensus::stats::AggregationWindow::Cumulative())
           .add_column("foo_id")
           .set_description(
               "Cumulative sum of example.com/Foo/FooUsage broken down "
               "by 'foo_id'.");
-  const auto interval_descriptor =
+  const auto count_descriptor =
       opencensus::stats::ViewDescriptor()
           .set_name("example.com/Bar/FooUsage-sum-interval-foo_id")
           .set_measure(kFooUsageMeasureName)
-          .set_aggregation(opencensus::stats::Aggregation::Sum())
-          .set_aggregation_window(
-              opencensus::stats::AggregationWindow::Interval(absl::Hours(1)))
+          .set_aggregation(opencensus::stats::Aggregation::Count())
           .add_column("foo_id")
           .set_description(
-              "Rolling sum of example.com/Foo/FooUsage over the previous hour "
-              "broken down by 'foo_id'.");
+              "Cumulative count of example.com/Foo/FooUsage broken down by "
+              "'foo_id'.");
 
   // The order of view registration and exporter creation does not matter, as
   // long as both precede data recording.
-  opencensus::stats::StatsExporter::AddView(cumulative_descriptor);
+  opencensus::stats::StatsExporter::AddView(sum_descriptor);
   ExampleExporter::Register();
-  opencensus::stats::StatsExporter::AddView(interval_descriptor);
+  opencensus::stats::StatsExporter::AddView(count_descriptor);
 
   // Someone calls the Foo API, recording usage under example.com/Bar/FooUsage.
   UseFoo("foo1", 1);

--- a/opencensus/stats/examples/view_and_recording_example.cc
+++ b/opencensus/stats/examples/view_and_recording_example.cc
@@ -63,8 +63,6 @@ TEST(ViewAndRecordingExample, Sum) {
           .set_name("example.com/Bar/FooUsage-sum-cumulative-foo_id")
           .set_measure(kFooUsageMeasureName)
           .set_aggregation(opencensus::stats::Aggregation::Sum())
-          .set_aggregation_window(
-              opencensus::stats::AggregationWindow::Cumulative())
           .add_column("foo_id")
           .set_description(
               "Cumulative sum of example.com/Foo/FooUsage broken down by "

--- a/opencensus/stats/internal/aggregation_window.h
+++ b/opencensus/stats/internal/aggregation_window.h
@@ -1,4 +1,4 @@
-// Copyright 2017, OpenCensus Authors
+// Copyright 2018, OpenCensus Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef OPENCENSUS_STATS_AGGREGATION_WINDOW_H_
-#define OPENCENSUS_STATS_AGGREGATION_WINDOW_H_
+#ifndef OPENCENSUS_STATS_INTERNAL_AGGREGATION_WINDOW_H_
+#define OPENCENSUS_STATS_INTERNAL_AGGREGATION_WINDOW_H_
 
 #include <string>
 
@@ -68,4 +68,4 @@ class AggregationWindow final {
 }  // namespace stats
 }  // namespace opencensus
 
-#endif  // OPENCENSUS_STATS_AGGREGATION_WINDOW_H_
+#endif  // OPENCENSUS_STATS_INTERNAL_AGGREGATION_WINDOW_H_

--- a/opencensus/stats/internal/debug_string_test.cc
+++ b/opencensus/stats/internal/debug_string_test.cc
@@ -16,8 +16,8 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "opencensus/stats/aggregation.h"
-#include "opencensus/stats/aggregation_window.h"
 #include "opencensus/stats/bucket_boundaries.h"
+#include "opencensus/stats/internal/aggregation_window.h"
 #include "opencensus/stats/measure_descriptor.h"
 #include "opencensus/stats/measure_registry.h"
 #include "opencensus/stats/view_descriptor.h"
@@ -64,9 +64,9 @@ TEST(DebugStringTest, ViewDescriptor) {
   ViewDescriptor descriptor = ViewDescriptor()
                                   .set_measure(measure_name)
                                   .set_aggregation(aggregation)
-                                  .set_aggregation_window(aggregation_window)
                                   .add_column(tag_key)
                                   .set_description(description);
+  SetAggregationWindow(aggregation_window, &descriptor);
 
   EXPECT_PRED_FORMAT2(::testing::IsSubstring,
                       measure.GetDescriptor().DebugString(),

--- a/opencensus/stats/internal/set_aggregation_window.cc
+++ b/opencensus/stats/internal/set_aggregation_window.cc
@@ -1,4 +1,4 @@
-// Copyright 2017, OpenCensus Authors
+// Copyright 2018, OpenCensus Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,21 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "opencensus/stats/internal/aggregation_window.h"
+#include "opencensus/stats/internal/set_aggregation_window.h"
 
-#include "absl/strings/str_cat.h"
+#include "opencensus/stats/internal/aggregation_window.h"
+#include "opencensus/stats/view_descriptor.h"
 
 namespace opencensus {
 namespace stats {
 
-std::string AggregationWindow::DebugString() const {
-  switch (type_) {
-    case Type::kCumulative:
-      return "Cumulative";
-    case Type::kInterval:
-      return absl::StrCat("Interval (", absl::ToDoubleSeconds(duration_),
-                          "s window)");
-  }
+void SetAggregationWindow(const AggregationWindow& window,
+                          ViewDescriptor* descriptor) {
+  descriptor->aggregation_window_ = window;
 }
 
 }  // namespace stats

--- a/opencensus/stats/internal/set_aggregation_window.h
+++ b/opencensus/stats/internal/set_aggregation_window.h
@@ -1,0 +1,34 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef OPENCENSUS_STATS_INTERNAL_SET_AGGREGATION_WINDOW_H_
+#define OPENCENSUS_STATS_INTERNAL_SET_AGGREGATION_WINDOW_H_
+
+#include "opencensus/stats/internal/aggregation_window.h"
+#include "opencensus/stats/view_descriptor.h"
+
+namespace opencensus {
+namespace stats {
+
+// You probably do not need this: ViewDescriptor has a Cumulative aggregation
+// window by default, and that is what most exporters expect. Interval
+// aggregation is mainly useful for on-task purposes, such as server status
+// displays.
+void SetAggregationWindow(const AggregationWindow& window,
+                          ViewDescriptor* descriptor);
+
+}  // namespace stats
+}  // namespace opencensus
+
+#endif  // OPENCENSUS_STATS_INTERNAL_SET_AGGREGATION_WINDOW_H_

--- a/opencensus/stats/internal/stats_exporter_test.cc
+++ b/opencensus/stats/internal/stats_exporter_test.cc
@@ -74,17 +74,15 @@ class StatsExporterTest : public ::testing::Test {
     descriptor1_.set_name("id1");
     descriptor1_.set_measure(kMeasureId);
     descriptor1_.set_aggregation(Aggregation::Count());
-    descriptor1_.set_aggregation_window(AggregationWindow::Cumulative());
     descriptor1_edited_.set_name("id1");
     descriptor1_edited_.set_measure(kMeasureId);
     descriptor1_edited_.set_aggregation(Aggregation::Sum());
-    descriptor1_edited_.set_aggregation_window(AggregationWindow::Cumulative());
     descriptor2_.set_name("id2");
     descriptor2_.set_measure(kMeasureId);
     descriptor2_.set_aggregation(
         Aggregation::Distribution(BucketBoundaries::Explicit({0})));
-    descriptor2_.set_aggregation_window(
-        AggregationWindow::Interval(absl::Hours(1)));
+    SetAggregationWindow(AggregationWindow::Interval(absl::Hours(1)),
+                         &descriptor2_);
   }
 
   void TearDown() {

--- a/opencensus/stats/internal/stats_manager_test.cc
+++ b/opencensus/stats/internal/stats_manager_test.cc
@@ -55,14 +55,12 @@ class StatsManagerTest : public ::testing::Test {
 };
 
 TEST_F(StatsManagerTest, Count) {
-  ViewDescriptor view_descriptor =
-      ViewDescriptor()
-          .set_measure(kFirstMeasureId)
-          .set_name("count")
-          .set_aggregation(Aggregation::Count())
-          .set_aggregation_window(AggregationWindow::Cumulative())
-          .add_column(key1_)
-          .add_column(key2_);
+  ViewDescriptor view_descriptor = ViewDescriptor()
+                                       .set_measure(kFirstMeasureId)
+                                       .set_name("count")
+                                       .set_aggregation(Aggregation::Count())
+                                       .add_column(key1_)
+                                       .add_column(key2_);
   View view(view_descriptor);
   ASSERT_EQ(ViewData::Type::kInt64, view.GetData().type());
   EXPECT_TRUE(view.GetData().int_data().empty());
@@ -83,14 +81,12 @@ TEST_F(StatsManagerTest, Count) {
 }
 
 TEST_F(StatsManagerTest, Sum) {
-  ViewDescriptor view_descriptor =
-      ViewDescriptor()
-          .set_measure(kSecondMeasureId)
-          .set_name("sum")
-          .set_aggregation(Aggregation::Sum())
-          .set_aggregation_window(AggregationWindow::Cumulative())
-          .add_column(key1_)
-          .add_column(key2_);
+  ViewDescriptor view_descriptor = ViewDescriptor()
+                                       .set_measure(kSecondMeasureId)
+                                       .set_name("sum")
+                                       .set_aggregation(Aggregation::Sum())
+                                       .add_column(key1_)
+                                       .add_column(key2_);
   View view(view_descriptor);
   ASSERT_EQ(ViewData::Type::kDouble, view.GetData().type());
   EXPECT_TRUE(view.GetData().double_data().empty());
@@ -117,7 +113,6 @@ TEST_F(StatsManagerTest, Distribution) {
           .set_name("distribution")
           .set_aggregation(
               Aggregation::Distribution(BucketBoundaries::Explicit({10})))
-          .set_aggregation_window(AggregationWindow::Cumulative())
           .add_column(key1_)
           .add_column(key2_);
   View view(view_descriptor);
@@ -143,14 +138,14 @@ TEST_F(StatsManagerTest, Distribution) {
 
 // TODO: Test window expiration if we add a simulated clock.
 TEST_F(StatsManagerTest, IntervalCount) {
-  ViewDescriptor view_descriptor =
-      ViewDescriptor()
-          .set_measure(kFirstMeasureId)
-          .set_name("interval-count")
-          .set_aggregation(Aggregation::Count())
-          .set_aggregation_window(AggregationWindow::Interval(absl::Minutes(1)))
-          .add_column(key1_)
-          .add_column(key2_);
+  ViewDescriptor view_descriptor = ViewDescriptor()
+                                       .set_measure(kFirstMeasureId)
+                                       .set_name("interval-count")
+                                       .set_aggregation(Aggregation::Count())
+                                       .add_column(key1_)
+                                       .add_column(key2_);
+  SetAggregationWindow(AggregationWindow::Interval(absl::Minutes(1)),
+                       &view_descriptor);
   View view(view_descriptor);
   ASSERT_EQ(ViewData::Type::kDouble, view.GetData().type());
   EXPECT_TRUE(view.GetData().double_data().empty());
@@ -171,14 +166,14 @@ TEST_F(StatsManagerTest, IntervalCount) {
 }
 
 TEST_F(StatsManagerTest, IntervalSum) {
-  ViewDescriptor view_descriptor =
-      ViewDescriptor()
-          .set_measure(kSecondMeasureId)
-          .set_name("interval-sum")
-          .set_aggregation(Aggregation::Sum())
-          .set_aggregation_window(AggregationWindow::Interval(absl::Hours(1)))
-          .add_column(key1_)
-          .add_column(key2_);
+  ViewDescriptor view_descriptor = ViewDescriptor()
+                                       .set_measure(kSecondMeasureId)
+                                       .set_name("interval-sum")
+                                       .set_aggregation(Aggregation::Sum())
+                                       .add_column(key1_)
+                                       .add_column(key2_);
+  SetAggregationWindow(AggregationWindow::Interval(absl::Minutes(1)),
+                       &view_descriptor);
   View view(view_descriptor);
   ASSERT_EQ(ViewData::Type::kDouble, view.GetData().type());
   EXPECT_TRUE(view.GetData().double_data().empty());
@@ -205,9 +200,10 @@ TEST_F(StatsManagerTest, IntervalDistribution) {
           .set_name("distribution-interval")
           .set_aggregation(
               Aggregation::Distribution(BucketBoundaries::Explicit({10})))
-          .set_aggregation_window(AggregationWindow::Interval(absl::Hours(1)))
           .add_column(key1_)
           .add_column(key2_);
+  SetAggregationWindow(AggregationWindow::Interval(absl::Hours(1)),
+                       &view_descriptor);
   View view(view_descriptor);
   ASSERT_EQ(ViewData::Type::kDistribution, view.GetData().type());
   EXPECT_TRUE(view.GetData().distribution_data().empty());
@@ -229,13 +225,11 @@ TEST_F(StatsManagerTest, IntervalDistribution) {
 }
 
 TEST_F(StatsManagerTest, IdenticalViews) {
-  ViewDescriptor view_descriptor =
-      ViewDescriptor()
-          .set_measure(kFirstMeasureId)
-          .set_name("count")
-          .set_aggregation(Aggregation::Count())
-          .set_aggregation_window(AggregationWindow::Cumulative())
-          .add_column(key1_);
+  ViewDescriptor view_descriptor = ViewDescriptor()
+                                       .set_measure(kFirstMeasureId)
+                                       .set_name("count")
+                                       .set_aggregation(Aggregation::Count())
+                                       .add_column(key1_);
 
   Record({{FirstMeasure(), 1.0}});
   {
@@ -270,12 +264,10 @@ TEST_F(StatsManagerTest, IdenticalViews) {
 
 TEST(StatsManagerDeathTest, UnregisteredMeasure) {
   const std::string measure_name = "new_measure_name";
-  ViewDescriptor view_descriptor =
-      ViewDescriptor()
-          .set_measure(measure_name)
-          .set_name("count")
-          .set_aggregation(Aggregation::Count())
-          .set_aggregation_window(AggregationWindow::Cumulative());
+  ViewDescriptor view_descriptor = ViewDescriptor()
+                                       .set_measure(measure_name)
+                                       .set_name("count")
+                                       .set_aggregation(Aggregation::Count());
 
   View view(view_descriptor);
   EXPECT_FALSE(view.IsValid());

--- a/opencensus/stats/internal/view_data_impl.h
+++ b/opencensus/stats/internal/view_data_impl.h
@@ -25,8 +25,8 @@
 #include "opencensus/common/internal/stats_object.h"
 #include "opencensus/common/internal/string_vector_hash.h"
 #include "opencensus/stats/aggregation.h"
-#include "opencensus/stats/aggregation_window.h"
 #include "opencensus/stats/distribution.h"
+#include "opencensus/stats/internal/aggregation_window.h"
 #include "opencensus/stats/view_descriptor.h"
 
 namespace opencensus {

--- a/opencensus/stats/internal/view_data_impl_test.cc
+++ b/opencensus/stats/internal/view_data_impl_test.cc
@@ -20,9 +20,10 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "opencensus/stats/aggregation.h"
-#include "opencensus/stats/aggregation_window.h"
 #include "opencensus/stats/bucket_boundaries.h"
 #include "opencensus/stats/distribution.h"
+#include "opencensus/stats/internal/aggregation_window.h"
+#include "opencensus/stats/internal/set_aggregation_window.h"
 #include "opencensus/stats/view_descriptor.h"
 
 namespace opencensus {
@@ -32,10 +33,7 @@ namespace {
 TEST(ViewDataImplTest, Sum) {
   const absl::Time start_time = absl::UnixEpoch();
   const absl::Time end_time = absl::UnixEpoch() + absl::Seconds(1);
-  const auto descriptor =
-      ViewDescriptor()
-          .set_aggregation(Aggregation::Sum())
-          .set_aggregation_window(AggregationWindow::Cumulative());
+  const auto descriptor = ViewDescriptor().set_aggregation(Aggregation::Sum());
   ViewDataImpl data(start_time, descriptor);
   const std::vector<std::string> tags1({"value1", "value2a"});
   const std::vector<std::string> tags2({"value1", "value2b"});
@@ -57,9 +55,7 @@ TEST(ViewDataImplTest, Count) {
   const absl::Time start_time = absl::UnixEpoch();
   const absl::Time end_time = absl::UnixEpoch() + absl::Seconds(1);
   const auto descriptor =
-      ViewDescriptor()
-          .set_aggregation(Aggregation::Count())
-          .set_aggregation_window(AggregationWindow::Cumulative());
+      ViewDescriptor().set_aggregation(Aggregation::Count());
   ViewDataImpl data(start_time, descriptor);
   const std::vector<std::string> tags1({"value1", "value2a"});
   const std::vector<std::string> tags2({"value1", "value2b"});
@@ -82,9 +78,7 @@ TEST(ViewDataImplTest, Distribution) {
   const absl::Time end_time = absl::UnixEpoch() + absl::Seconds(1);
   const BucketBoundaries buckets = BucketBoundaries::Explicit({10});
   const auto descriptor =
-      ViewDescriptor()
-          .set_aggregation(Aggregation::Distribution(buckets))
-          .set_aggregation_window(AggregationWindow::Cumulative());
+      ViewDescriptor().set_aggregation(Aggregation::Distribution(buckets));
   ViewDataImpl data(start_time, descriptor);
   const std::vector<std::string> tags1({"value1", "value2a"});
   const std::vector<std::string> tags2({"value1", "value2b"});
@@ -108,10 +102,8 @@ TEST(ViewDataImplTest, StatsObjectToCount) {
   const absl::Duration interval = absl::Minutes(1);
   const absl::Time start_time = absl::UnixEpoch();
   absl::Time time = start_time;
-  const auto descriptor =
-      ViewDescriptor()
-          .set_aggregation(Aggregation::Count())
-          .set_aggregation_window(AggregationWindow::Interval(interval));
+  auto descriptor = ViewDescriptor().set_aggregation(Aggregation::Count());
+  SetAggregationWindow(AggregationWindow::Interval(interval), &descriptor);
   ViewDataImpl data(start_time, descriptor);
   const std::vector<std::string> tags1({"value1", "value2a"});
   const std::vector<std::string> tags2({"value1", "value2b"});
@@ -145,10 +137,8 @@ TEST(ViewDataImplTest, StatsObjectToSum) {
   const absl::Duration interval = absl::Minutes(1);
   const absl::Time start_time = absl::UnixEpoch();
   absl::Time time = start_time;
-  const auto descriptor =
-      ViewDescriptor()
-          .set_aggregation(Aggregation::Sum())
-          .set_aggregation_window(AggregationWindow::Interval(interval));
+  auto descriptor = ViewDescriptor().set_aggregation(Aggregation::Sum());
+  SetAggregationWindow(AggregationWindow::Interval(interval), &descriptor);
   ViewDataImpl data(start_time, descriptor);
   const std::vector<std::string> tags1({"value1", "value2a"});
   const std::vector<std::string> tags2({"value1", "value2b"});
@@ -183,10 +173,9 @@ TEST(ViewDataImplTest, StatsObjectToDistribution) {
   const absl::Time start_time = absl::UnixEpoch();
   absl::Time time = start_time;
   const BucketBoundaries buckets = BucketBoundaries::Explicit({10});
-  const auto descriptor =
-      ViewDescriptor()
-          .set_aggregation(Aggregation::Distribution(buckets))
-          .set_aggregation_window(AggregationWindow::Interval(interval));
+  auto descriptor =
+      ViewDescriptor().set_aggregation(Aggregation::Distribution(buckets));
+  SetAggregationWindow(AggregationWindow::Interval(interval), &descriptor);
   ViewDataImpl data(start_time, descriptor);
   const std::vector<std::string> tags1({"value1", "value2a"});
   const std::vector<std::string> tags2({"value1", "value2b"});

--- a/opencensus/stats/internal/view_descriptor.cc
+++ b/opencensus/stats/internal/view_descriptor.cc
@@ -53,12 +53,6 @@ ViewDescriptor& ViewDescriptor::set_aggregation(
   return *this;
 }
 
-ViewDescriptor& ViewDescriptor::set_aggregation_window(
-    const AggregationWindow& window) {
-  aggregation_window_ = window;
-  return *this;
-}
-
 ViewDescriptor& ViewDescriptor::add_column(absl::string_view tag_key) {
   columns_.emplace_back(tag_key);
   return *this;

--- a/opencensus/stats/stats.h
+++ b/opencensus/stats/stats.h
@@ -18,7 +18,6 @@
 // Re-export the public headers for stats so that users do not need to maintain
 // a long include list.
 #include "opencensus/stats/aggregation.h"         // IWYU pragma: export
-#include "opencensus/stats/aggregation_window.h"  // IWYU pragma: export
 #include "opencensus/stats/bucket_boundaries.h"   // IWYU pragma: export
 #include "opencensus/stats/measure.h"             // IWYU pragma: export
 #include "opencensus/stats/measure_descriptor.h"  // IWYU pragma: export

--- a/opencensus/stats/view_data.h
+++ b/opencensus/stats/view_data.h
@@ -24,8 +24,8 @@
 #include "opencensus/common/internal/stats_object.h"
 #include "opencensus/common/internal/string_vector_hash.h"
 #include "opencensus/stats/aggregation.h"
-#include "opencensus/stats/aggregation_window.h"
 #include "opencensus/stats/distribution.h"
+#include "opencensus/stats/internal/aggregation_window.h"
 
 namespace opencensus {
 namespace stats {

--- a/opencensus/stats/view_descriptor.h
+++ b/opencensus/stats/view_descriptor.h
@@ -21,7 +21,7 @@
 
 #include "absl/strings/string_view.h"
 #include "opencensus/stats/aggregation.h"
-#include "opencensus/stats/aggregation_window.h"
+#include "opencensus/stats/internal/aggregation_window.h"
 #include "opencensus/stats/measure_descriptor.h"
 
 namespace opencensus {
@@ -47,7 +47,6 @@ class ViewDescriptor final {
   ViewDescriptor& set_aggregation(const Aggregation& aggregation);
   const Aggregation& aggregation() const { return aggregation_; }
 
-  ViewDescriptor& set_aggregation_window(const AggregationWindow& window);
   const AggregationWindow& aggregation_window() const {
     return aggregation_window_;
   }
@@ -68,6 +67,7 @@ class ViewDescriptor final {
 
  private:
   friend class StatsManager;
+  friend void SetAggregationWindow(const AggregationWindow&, ViewDescriptor*);
 
   std::string name_;
   std::string measure_name_;


### PR DESCRIPTION
Most exporters can only handle Cumulative aggregation, and few users have need of Internal; this makes Cumulative the default and moves the ability to set Interval aggregation to a separate header in stats/internal. Pursuant to https://github.com/census-instrumentation/opencensus-specs/issues/47.