### PR TITLE
Change BucketBoundaries' internal constructor to take a vector by value.

### DIFF
--- a/opencensus/stats/bucket_boundaries.h
+++ b/opencensus/stats/bucket_boundaries.h
@@ -16,11 +16,9 @@
 #define OPENCENSUS_STATS_BUCKET_BOUNDARIES_H_
 
 #include <cstddef>
-#include <initializer_list>
 #include <string>
+#include <utility>
 #include <vector>
-
-#include "absl/types/span.h"
 
 namespace opencensus {
 namespace stats {
@@ -53,7 +51,7 @@ class BucketBoundaries final {
   // [boundaries[i], boundaries[i+1]), as well as an underflow bucket covering
   // [-inf, boundaries[0]) and an overflow bucket covering
   // [boundaries[boundaries.size()-1], inf].
-  static BucketBoundaries Explicit(std::initializer_list<double> boundaries);
+  static BucketBoundaries Explicit(std::vector<double> boundaries);
 
   // The number of buckets in a Distribution using this bucketer.
   int num_buckets() const { return lower_boundaries_.size() + 1; }
@@ -74,8 +72,8 @@ class BucketBoundaries final {
   }
 
  private:
-  BucketBoundaries(absl::Span<const double> lower_boundaries)
-      : lower_boundaries_(lower_boundaries.begin(), lower_boundaries.end()) {}
+  BucketBoundaries(std::vector<double> lower_boundaries)
+      : lower_boundaries_(std::move(lower_boundaries)) {}
 
   // The lower bound of each bucket, excluding the underflow bucket but
   // including the overflow bucket.

--- a/opencensus/stats/internal/bucket_boundaries.cc
+++ b/opencensus/stats/internal/bucket_boundaries.cc
@@ -16,6 +16,7 @@
 
 #include <algorithm>
 #include <iostream>
+#include <vector>
 
 #include "absl/base/macros.h"
 #include "absl/strings/str_cat.h"
@@ -39,7 +40,7 @@ BucketBoundaries BucketBoundaries::Linear(int num_finite_buckets, double offset,
     boundaries[i] = boundary;
     boundary += width;
   }
-  return BucketBoundaries(boundaries);
+  return BucketBoundaries(std::move(boundaries));
 }
 
 // static
@@ -52,20 +53,18 @@ BucketBoundaries BucketBoundaries::Exponential(int num_finite_buckets,
     boundaries[i] = upper_bound;
     upper_bound *= growth_factor;
   }
-  return BucketBoundaries(boundaries);
+  return BucketBoundaries(std::move(boundaries));
 }
 
 // static
-BucketBoundaries BucketBoundaries::Explicit(
-    std::initializer_list<double> boundaries) {
+BucketBoundaries BucketBoundaries::Explicit(std::vector<double> boundaries) {
   if (!std::is_sorted(boundaries.begin(), boundaries.end())) {
     std::cerr << "BucketBoundaries::Explicit called with non-monotonic "
                  "boundary list.\n";
     ABSL_ASSERT(0);
     return BucketBoundaries({});
   }
-  return BucketBoundaries(
-      absl::Span<const double>(boundaries.begin(), boundaries.size()));
+  return BucketBoundaries(std::move(boundaries));
 }
 
 int BucketBoundaries::BucketForValue(double value) const {


### PR DESCRIPTION
This better accords with conventions (https://github.com/census-instrumentation/opencensus-cpp/blob/master/opencensus/doc/conventions.md#classes-that-take-an-object-and-store-it) and avoids a copy for the Linear and Exponential constructors.

Closes #21