### PR TITLE
Take a const reference to string values to avoid making a string_piece from a local variable.

### DIFF
--- a/opencensus/trace/attribute_value_ref.h
+++ b/opencensus/trace/attribute_value_ref.h
@@ -52,8 +52,8 @@ class AttributeValueRef final {
   // have to handle const char[] separately.
   template <typename T, typename std::enable_if<std::is_constructible<
                             absl::string_view, T>::value>::type* = nullptr>
-  AttributeValueRef(T string_value)
-      : string_value_(absl::string_view(string_value)), type_(Type::kString) {}
+  AttributeValueRef(const T& string_value)
+      : string_value_(string_value), type_(Type::kString) {}
 
   // Construct from integer. We have to supply this form explicitly because
   // otherwise AttributeValueRef(int) is ambiguous between int and bool!


### PR DESCRIPTION
Closes #22.