### PR TITLE
Pass AttributeValueRef by value to AttributeValue constructor.

### DIFF
--- a/opencensus/trace/exporter/attribute_value.h
+++ b/opencensus/trace/exporter/attribute_value.h
@@ -38,7 +38,7 @@ class AttributeValue final {
   // The type of value held by this object.
   using Type = AttributeValueRef::Type;
 
-  explicit AttributeValue(const AttributeValueRef& ref);
+  explicit AttributeValue(AttributeValueRef ref);
   ~AttributeValue();
 
   // AttributeValue is copyable and movable.

--- a/opencensus/trace/internal/attribute_value.cc
+++ b/opencensus/trace/internal/attribute_value.cc
@@ -25,7 +25,7 @@ namespace opencensus {
 namespace trace {
 namespace exporter {
 
-AttributeValue::AttributeValue(const AttributeValueRef& ref)
+AttributeValue::AttributeValue(AttributeValueRef ref)
     : type_(ref.type()) {
   switch (type_) {
     case Type::kString:

--- a/opencensus/trace/internal/attribute_value.cc
+++ b/opencensus/trace/internal/attribute_value.cc
@@ -25,8 +25,7 @@ namespace opencensus {
 namespace trace {
 namespace exporter {
 
-AttributeValue::AttributeValue(AttributeValueRef ref)
-    : type_(ref.type()) {
+AttributeValue::AttributeValue(AttributeValueRef ref) : type_(ref.type()) {
   switch (type_) {
     case Type::kString:
       new (&string_value_) std::string(ref.string_value());


### PR DESCRIPTION
This can potentially avoid materializing the AttributeValueRef object,
which is essentially POD and has no destructor.