### PR TITLE
Add bazel.rc and presubmit script.

### DIFF
--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -1,0 +1,25 @@
+# bazel configurations for running tests under sanitizers.
+# Based on https://github.com/bazelment/trunk/blob/master/tools/bazel.rc
+
+# --config=asan : Address Sanitizer.
+build:asan --copt -fsanitize=address
+build:asan --copt -DADDRESS_SANITIZER
+build:asan --linkopt -fsanitize=address
+
+# --config=msan : Memory Sanitizer.
+# TODO: This doesn't work with gcc.
+#build:msan --copt -fsanitize=memory
+#build:msan --copt -DMEMORY_SANITIZER
+#build:msan --linkopt -fsanitize=memory
+
+# --config=tsan : Thread Sanitizer.
+# TODO: Enable this once it works. Currently breaks build in absl's mutex.cc.
+#build:tsan --copt -fsanitize=thread
+#build:tsan --copt -DTHREAD_SANITIZER
+#build:tsan --copt -DDYNAMIC_ANNOTATIONS_ENABLED=1
+#build:tsan --copt -DDYNAMIC_ANNOTATIONS_EXTERNAL_IMPL=1
+#build:tsan --linkopt -fsanitize=thread
+
+# --config=ubsan : Undefined Behavior Sanitizer.
+build:ubsan --copt -fsanitize=undefined
+build:ubsan --linkopt -fsanitize=undefined

--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -2,24 +2,26 @@
 # Based on https://github.com/bazelment/trunk/blob/master/tools/bazel.rc
 
 # --config=asan : Address Sanitizer.
-build:asan --copt -fsanitize=address
-build:asan --copt -DADDRESS_SANITIZER
-build:asan --linkopt -fsanitize=address
+common:asan --copt -fsanitize=address
+common:asan --copt -DADDRESS_SANITIZER
+common:asan --linkopt -fsanitize=address
+common:asan --cc_output_directory_tag=asan
 
 # --config=msan : Memory Sanitizer.
 # TODO: This doesn't work with gcc.
-#build:msan --copt -fsanitize=memory
-#build:msan --copt -DMEMORY_SANITIZER
-#build:msan --linkopt -fsanitize=memory
+#common:msan --copt -fsanitize=memory
+#common:msan --copt -DMEMORY_SANITIZER
+#common:msan --linkopt -fsanitize=memory
 
 # --config=tsan : Thread Sanitizer.
 # TODO: Enable this once it works. Currently breaks build in absl's mutex.cc.
-#build:tsan --copt -fsanitize=thread
-#build:tsan --copt -DTHREAD_SANITIZER
-#build:tsan --copt -DDYNAMIC_ANNOTATIONS_ENABLED=1
-#build:tsan --copt -DDYNAMIC_ANNOTATIONS_EXTERNAL_IMPL=1
-#build:tsan --linkopt -fsanitize=thread
+#common:tsan --copt -fsanitize=thread
+#common:tsan --copt -DTHREAD_SANITIZER
+#common:tsan --copt -DDYNAMIC_ANNOTATIONS_ENABLED=1
+#common:tsan --copt -DDYNAMIC_ANNOTATIONS_EXTERNAL_IMPL=1
+#common:tsan --linkopt -fsanitize=thread
 
 # --config=ubsan : Undefined Behavior Sanitizer.
-build:ubsan --copt -fsanitize=undefined
-build:ubsan --linkopt -fsanitize=undefined
+common:ubsan --copt -fsanitize=undefined
+common:ubsan --linkopt -fsanitize=undefined
+common:ubsan --cc_output_directory_tag=ubsan

--- a/tools/presubmit.sh
+++ b/tools/presubmit.sh
@@ -44,7 +44,6 @@ buildables="-- $(bazel query -k --noshow_progress "kind('^cc', //...)")"
 
 tests="-- $(bazel query -k --noshow_progress \
   "kind(test, //...) \
-   except attr('tags', 'noci', //...) \
    except attr('tags', 'manual', //...)")"
 
 run bazel build $buildables

--- a/tools/presubmit.sh
+++ b/tools/presubmit.sh
@@ -1,4 +1,4 @@
-#! /usr/bin/env bash
+#!/usr/bin/env bash
 #
 # Copyright 2018, OpenCensus Authors
 #
@@ -14,15 +14,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This script runs a slow but complete check of the code to make sure:
+# presubmit:
+# Run a slow but complete check of the code to make sure:
 #   - Everything builds.
 #   - Tests pass.
 #   - Sanitizers pass.
+#
+# This is intended to be run manually and locally, not as part of
+# continuous integration.
 
 readonly R="======================================="
-readonly BOLD="\033[1m"
-readonly ERR="\033[31;1m"
-readonly NORMAL="\033[0m"
+readonly BOLD="\\033[1m"
+readonly ERR="\\033[31;1m"
+readonly NORMAL="\\033[0m"
 
 function run() {
   echo ""

--- a/tools/presubmit.sh
+++ b/tools/presubmit.sh
@@ -1,0 +1,63 @@
+#! /usr/bin/env bash
+#
+# Copyright 2018, OpenCensus Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script runs a slow but complete check of the code to make sure:
+#   - Everything builds.
+#   - Tests pass.
+#   - Sanitizers pass.
+
+readonly R="======================================="
+readonly BOLD="\033[1m"
+readonly ERR="\033[31;1m"
+readonly NORMAL="\033[0m"
+
+function run() {
+  echo ""
+  echo -e "${BOLD}${R}${R}"
+  echo "Running: $@"
+  echo -e "${R}${R}${NORMAL}"
+  $@
+  ret="$?"
+  if [[ "${ret}" -ne 0 ]]; then
+    echo ""
+    echo -e "${ERR}>>> Error: returned code ${ret} <<<${NORMAL}"
+    exit ${ret}
+  fi
+}
+
+t0="$(date +%s)"
+
+buildables="-- $(bazel query -k --noshow_progress "kind('^cc', //...)")"
+
+tests="-- $(bazel query -k --noshow_progress \
+  "kind(test, //...) \
+   except attr('tags', 'noci', //...) \
+   except attr('tags', 'manual', //...)")"
+
+run bazel build $buildables
+run bazel test $tests
+
+run bazel build -c opt $buildables
+run bazel test -c opt $tests
+
+for config in asan ubsan; do
+  run bazel test --config=$config $tests
+  run bazel test --config=$config -c opt $tests
+done
+
+t1="$(date +%s)"
+echo ""
+echo "Succeeded after $((t1 - t0)) secs."


### PR DESCRIPTION
The bazel.rc file has configs for address sanitizer (--config=asan) and
ubsan.

The presubmit script is a heavyweight version of tools/ci.sh which
builds and tests everything, including opt mode and sanitizers.