### PR TITLE
Change initializer_list to absl::Span to accept vectors and arrays.

### DIFF
--- a/opencensus/trace/BUILD
+++ b/opencensus/trace/BUILD
@@ -87,6 +87,7 @@ cc_library(
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/synchronization",
         "@com_google_absl//absl/time",
+        "@com_google_absl//absl/types:span",
         "//opencensus/common/internal:random_lib",
     ],
 )

--- a/opencensus/trace/internal/span_test.cc
+++ b/opencensus/trace/internal/span_test.cc
@@ -99,6 +99,25 @@ TEST(SpanTest, AddAttributesLastValueWins) {
             data.attributes().at("another_key").string_value());
 }
 
+TEST(SpanTest, AddAttributesWithArrayAndVector) {
+  auto span =
+      Span::StartSpan("SpanName", /*parent=*/nullptr, {nullptr, kRecordEvents});
+  std::array<std::pair<absl::string_view, AttributeValueRef>, 3>
+      attributes_array = {
+          {{"str_key", "value1"}, {"int_key", 123}, {"bool_key", true}}};
+  std::vector<std::pair<absl::string_view, AttributeValueRef>>
+      attributes_vector = {{"another_key", "another_value"}};
+  span.AddAttributes(attributes_array);
+  span.AddAttributes(attributes_vector);
+  auto data = SpanTestPeer::ToSpanData(&span);
+  span.End();
+  EXPECT_EQ("value1", data.attributes().at("str_key").string_value());
+  EXPECT_EQ(123, data.attributes().at("int_key").int_value());
+  EXPECT_EQ(true, data.attributes().at("bool_key").bool_value());
+  EXPECT_EQ("another_value",
+            data.attributes().at("another_key").string_value());
+}
+
 TEST(SpanTest, AddAnnotationLastAttributeWins) {
   auto span =
       Span::StartSpan("SpanName", /*parent=*/nullptr, {nullptr, kRecordEvents});

--- a/opencensus/trace/span.h
+++ b/opencensus/trace/span.h
@@ -20,6 +20,7 @@
 #include <vector>
 
 #include "absl/strings/string_view.h"
+#include "absl/types/span.h"
 #include "opencensus/trace/attribute_value_ref.h"
 #include "opencensus/trace/sampler.h"
 #include "opencensus/trace/span_context.h"
@@ -45,7 +46,7 @@ class SpanTestPeer;
 // Attributes to the tracing API. e.g.:
 //   AddAttributes({{"key1", "value1"}, {"key2", 123}});
 using AttributesRef =
-    std::initializer_list<std::pair<absl::string_view, AttributeValueRef>>;
+    absl::Span<const std::pair<absl::string_view, AttributeValueRef>>;
 
 // Options for Starting a Span.
 struct StartSpanOptions {


### PR DESCRIPTION
Fixes https://github.com/census-instrumentation/opencensus-cpp/issues/43