### PR TITLE
Changes to the stats exporter interface

### DIFF
--- a/opencensus/exporters/stats/stackdriver/internal/stackdriver_exporter.cc
+++ b/opencensus/exporters/stats/stackdriver/internal/stackdriver_exporter.cc
@@ -73,11 +73,6 @@ void StackdriverExporter::Handler::ExportViewData(
     const opencensus::stats::ViewDescriptor& descriptor,
     const opencensus::stats::ViewData& data) {
   absl::MutexLock l(&mu_);
-  // Stackdriver does not support interval aggregation.
-  if (descriptor.aggregation_window().type() !=
-      opencensus::stats::AggregationWindow::Type::kCumulative) {
-    return;
-  }
   if (!MaybeRegisterView(descriptor)) {
     return;
   }

--- a/opencensus/exporters/stats/stackdriver/internal/stackdriver_exporter.cc
+++ b/opencensus/exporters/stats/stackdriver/internal/stackdriver_exporter.cc
@@ -134,7 +134,7 @@ bool StackdriverExporter::Handler::MaybeRegisterView(
 // static
 void StackdriverExporter::Register(absl::string_view project_id,
                                    absl::string_view opencensus_task) {
-  opencensus::stats::StatsExporter::RegisterHandler(absl::WrapUnique(
+  opencensus::stats::StatsExporter::RegisterPushHandler(absl::WrapUnique(
       new StackdriverExporter::Handler(project_id, opencensus_task)));
 }
 

--- a/opencensus/exporters/stats/stdout/internal/stdout_exporter.cc
+++ b/opencensus/exporters/stats/stdout/internal/stdout_exporter.cc
@@ -55,7 +55,7 @@ class StdoutExporter::Handler
 
 // static
 void StdoutExporter::Register() {
-  opencensus::stats::StatsExporter::RegisterHandler(
+  opencensus::stats::StatsExporter::RegisterPushHandler(
       absl::make_unique<StdoutExporter::Handler>());
 }
 

--- a/opencensus/stats/BUILD
+++ b/opencensus/stats/BUILD
@@ -183,6 +183,7 @@ cc_test(
     deps = [
         ":core",
         ":export",
+        ":recording",
         "@com_google_absl//absl/memory",
         "@com_google_absl//absl/time",
         "@com_google_googletest//:gtest_main",

--- a/opencensus/stats/examples/exporter_example.cc
+++ b/opencensus/stats/examples/exporter_example.cc
@@ -38,7 +38,7 @@ opencensus::stats::MeasureDouble FooUsage() {
 class ExampleExporter : public opencensus::stats::StatsExporter::Handler {
  public:
   static void Register() {
-    opencensus::stats::StatsExporter::RegisterHandler(
+    opencensus::stats::StatsExporter::RegisterPushHandler(
         absl::make_unique<ExampleExporter>());
   }
 

--- a/opencensus/stats/internal/stats_exporter.cc
+++ b/opencensus/stats/internal/stats_exporter.cc
@@ -14,6 +14,7 @@
 
 #include "opencensus/stats/stats_exporter.h"
 
+#include <iostream>
 #include <thread>  // NOLINT
 #include <utility>
 #include <vector>
@@ -22,6 +23,7 @@
 #include "absl/synchronization/mutex.h"
 #include "absl/time/clock.h"
 #include "absl/time/time.h"
+#include "opencensus/stats/internal/aggregation_window.h"
 
 namespace opencensus {
 namespace stats {
@@ -118,7 +120,12 @@ class StatsExporterImpl {
 };
 
 void StatsExporter::AddView(const ViewDescriptor& view) {
-  StatsExporterImpl::Get()->AddView(view);
+  if (view.aggregation_window().type() ==
+      AggregationWindow::Type::kCumulative) {
+    StatsExporterImpl::Get()->AddView(view);
+  } else {
+    std::cerr << "Only cumulative views may be registered for export.\n";
+  }
 }
 
 void StatsExporter::RemoveView(absl::string_view name) {

--- a/opencensus/stats/stats_exporter.h
+++ b/opencensus/stats/stats_exporter.h
@@ -34,7 +34,8 @@ namespace stats {
 // StatsExporter is thread-safe.
 class StatsExporter final {
  public:
-  // Inserts a new view, replacing any existing view with the same name.
+  // Inserts a new view, replacing any existing view with the same name. Only
+  // Cumulative views are supported.
   static void AddView(const ViewDescriptor& view);
   // Removes the view with 'name' from the registry, if one is registered.
   static void RemoveView(absl::string_view name);

--- a/opencensus/stats/stats_exporter.h
+++ b/opencensus/stats/stats_exporter.h
@@ -19,6 +19,8 @@
 #include <functional>
 #include <memory>
 #include <unordered_map>
+#include <utility>
+#include <vector>
 
 #include "absl/strings/string_view.h"
 #include "opencensus/stats/view.h"
@@ -37,10 +39,10 @@ class StatsExporter final {
   // Removes the view with 'name' from the registry, if one is registered.
   static void RemoveView(absl::string_view name);
 
-  // StatsExporter::Handler is the interface for exporters that export recorded
-  // data for registered views. The exporter should provide a static Register()
-  // method that takes any arguments needed by the exporter (e.g. a URL to
-  // export to) and calls StatsExporter::RegisterHandler itself.
+  // StatsExporter::Handler is the interface for push exporters that export
+  // recorded data for registered views. The exporter should provide a static
+  // Register() method that takes any arguments needed by the exporter (e.g. a
+  // URL to export to) and calls StatsExporter::RegisterHandler itself.
   class Handler {
    public:
     virtual ~Handler() = default;
@@ -48,8 +50,12 @@ class StatsExporter final {
                                 const ViewData& data) = 0;
   };
 
-  // This should only be called by Handler's Register() methods.
-  static void RegisterHandler(std::unique_ptr<Handler> handler);
+  // This should only be called by push exporters' Register() methods.
+  static void RegisterPushHandler(std::unique_ptr<Handler> handler);
+
+  // Retrieves current data for all registered views, for implementing pull
+  // exporters.
+  static std::vector<std::pair<ViewDescriptor, ViewData>> GetViewData();
 
  private:
   friend class StatsExporterTest;


### PR DESCRIPTION
Add an interface for pull exporters, and disallow registering non-cumulative views--Stackdriver and Prometheus both require cumulative views, and allowing but then ignoring cumulative views is likely confusing.