### PR TITLE
Add registration interfaces to ViewDescriptor.

### DIFF
--- a/opencensus/exporters/stats/prometheus/internal/prometheus_test_server.cc
+++ b/opencensus/exporters/stats/prometheus/internal/prometheus_test_server.cc
@@ -44,7 +44,7 @@ int main(int argc, char** argv) {
           .set_description(
               "Cumulative distribution of example.com/Foo/FooUsage broken down "
               "by 'key1' and 'key2'.");
-  opencensus::stats::StatsExporter::AddView(view_descriptor);
+  view_descriptor.RegisterForExport();
 
   std::cout << "Access metrics on http://127.0.0.1:8080/metrics\n";
   while (true) {

--- a/opencensus/exporters/stats/stackdriver/internal/stackdriver_e2e_test.cc
+++ b/opencensus/exporters/stats/stackdriver/internal/stackdriver_e2e_test.cc
@@ -166,7 +166,7 @@ TEST_F(StackdriverE2eTest, OneView) {
           .set_description(
               "Cumulative sum of opencensus.io/TestMeasure broken down "
               "by 'key1' and 'key2'.");
-  opencensus::stats::StatsExporter::AddView(view_descriptor);
+  view_descriptor.RegisterForExport();
 
   opencensus::stats::Record({{TestMeasure(), 1.0}},
                             {{"key1", "v11"}, {"key2", "v21"}});
@@ -202,7 +202,7 @@ TEST_F(StackdriverE2eTest, LargeTest) {
           .set_description(
               "Cumulative count of opencensus.io/TestMeasure broken down "
               "by 'key1' and 'key2'.");
-  opencensus::stats::StatsExporter::AddView(count_descriptor);
+  count_descriptor.RegisterForExport();
 
   const auto sum_descriptor =
       opencensus::stats::ViewDescriptor()
@@ -216,7 +216,7 @@ TEST_F(StackdriverE2eTest, LargeTest) {
           .set_description(
               "Cumulative sum of opencensus.io/TestMeasure broken down "
               "by 'key1' and 'key2'.");
-  opencensus::stats::StatsExporter::AddView(sum_descriptor);
+  sum_descriptor.RegisterForExport();
 
   std::vector<::testing::Matcher<google::monitoring::v3::TimeSeries>>
       sum_matchers;

--- a/opencensus/stats/BUILD
+++ b/opencensus/stats/BUILD
@@ -31,7 +31,6 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         ":core",
-        ":export",
         ":recording",
     ],
 )
@@ -63,7 +62,9 @@ cc_library(
         "internal/measure_registry.cc",
         "internal/measure_registry_impl.cc",
         "internal/set_aggregation_window.cc",
+        "internal/stats_exporter.cc",
         "internal/stats_manager.cc",
+        "internal/view.cc",
         "internal/view_data.cc",
         "internal/view_data_impl.cc",
         "internal/view_descriptor.cc",
@@ -75,11 +76,14 @@ cc_library(
         "internal/aggregation_window.h",
         "internal/measure_registry_impl.h",
         "internal/set_aggregation_window.h",
+        "internal/stats_exporter_impl.h",
         "internal/stats_manager.h",
         "internal/view_data_impl.h",
         "measure.h",
         "measure_descriptor.h",
         "measure_registry.h",
+        "stats_exporter.h",
+        "view.h",
         "view_data.h",
         "view_descriptor.h",
     ],
@@ -105,27 +109,6 @@ cc_library(
     deps = [
         ":core",
         "@com_google_absl//absl/strings",
-        "@com_google_absl//absl/time",
-    ],
-)
-
-cc_library(
-    name = "export",
-    srcs = [
-        "internal/stats_exporter.cc",
-        "internal/view.cc",
-    ],
-    hdrs = [
-        "stats_exporter.h",
-        "view.h",
-    ],
-    copts = DEFAULT_COPTS,
-    deps = [
-        ":core",
-        "@com_google_absl//absl/base:core_headers",
-        "@com_google_absl//absl/memory",
-        "@com_google_absl//absl/strings",
-        "@com_google_absl//absl/synchronization",
         "@com_google_absl//absl/time",
     ],
 )
@@ -182,7 +165,6 @@ cc_test(
     copts = TEST_COPTS,
     deps = [
         ":core",
-        ":export",
         ":recording",
         "@com_google_absl//absl/memory",
         "@com_google_absl//absl/time",
@@ -196,7 +178,6 @@ cc_test(
     copts = TEST_COPTS,
     deps = [
         ":core",
-        ":export",
         ":recording",
         "@com_google_absl//absl/types:optional",
         "@com_google_googletest//:gtest_main",
@@ -237,7 +218,6 @@ cc_binary(
     linkstatic = 1,
     deps = [
         ":core",
-        ":export",
         ":recording",
         "@com_google_absl//absl/memory",
         "@com_google_absl//absl/strings",

--- a/opencensus/stats/examples/exporter_example.cc
+++ b/opencensus/stats/examples/exporter_example.cc
@@ -98,9 +98,9 @@ TEST_F(ExporterExample, Distribution) {
 
   // The order of view registration and exporter creation does not matter, as
   // long as both precede data recording.
-  opencensus::stats::StatsExporter::AddView(sum_descriptor);
+  sum_descriptor.RegisterForExport();
   ExampleExporter::Register();
-  opencensus::stats::StatsExporter::AddView(count_descriptor);
+  count_descriptor.RegisterForExport();
 
   // Someone calls the Foo API, recording usage under example.com/Bar/FooUsage.
   UseFoo("foo1", 1);

--- a/opencensus/stats/internal/stats_exporter.cc
+++ b/opencensus/stats/internal/stats_exporter.cc
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 #include "opencensus/stats/stats_exporter.h"
+#include "opencensus/stats/internal/stats_exporter_impl.h"
 
-#include <iostream>
 #include <thread>  // NOLINT
 #include <utility>
 #include <vector>
@@ -24,107 +24,83 @@
 #include "absl/time/clock.h"
 #include "absl/time/time.h"
 #include "opencensus/stats/internal/aggregation_window.h"
+#include "opencensus/stats/view_data.h"
+#include "opencensus/stats/view_descriptor.h"
 
 namespace opencensus {
 namespace stats {
 
-class StatsExporterImpl {
- public:
-  static StatsExporterImpl* Get() {
-    static StatsExporterImpl* global_stats_exporter_impl =
-        new StatsExporterImpl();
-    return global_stats_exporter_impl;
+// static
+StatsExporterImpl* StatsExporterImpl::Get() {
+  static StatsExporterImpl* global_stats_exporter_impl =
+      new StatsExporterImpl();
+  return global_stats_exporter_impl;
+}
+
+void StatsExporterImpl::AddView(const ViewDescriptor& view) {
+  absl::MutexLock l(&mu_);
+  views_[view.name()] = absl::make_unique<opencensus::stats::View>(view);
+}
+
+void StatsExporterImpl::RemoveView(absl::string_view name) {
+  absl::MutexLock l(&mu_);
+  views_.erase(std::string(name));
+}
+
+void StatsExporterImpl::RegisterPushHandler(
+    std::unique_ptr<StatsExporter::Handler> handler) {
+  absl::MutexLock l(&mu_);
+  handlers_.push_back(std::move(handler));
+  if (!thread_started_) {
+    StartExportThread();
   }
+}
 
-  void AddView(const ViewDescriptor& view) {
-    absl::MutexLock l(&mu_);
-    views_[view.name()] = absl::make_unique<opencensus::stats::View>(view);
+std::vector<std::pair<ViewDescriptor, ViewData>>
+StatsExporterImpl::GetViewData() {
+  absl::ReaderMutexLock l(&mu_);
+  std::vector<std::pair<ViewDescriptor, ViewData>> data;
+  data.reserve(views_.size());
+  for (const auto& view : views_) {
+    data.emplace_back(view.second->descriptor(), view.second->GetData());
   }
+  return data;
+}
 
-  void RemoveView(absl::string_view name) {
-    absl::MutexLock l(&mu_);
-    views_.erase(std::string(name));
+void StatsExporterImpl::Export() {
+  absl::ReaderMutexLock l(&mu_);
+  for (const auto& view : views_) {
+    SendToHandlers(view.second->descriptor(), view.second->GetData());
   }
+}
 
-  // Adds a handler, which cannot be subsequently removed (except by
-  // ClearHandlersForTesting()). The background thread is started when the
-  // first handler is registered.
-  void RegisterPushHandler(std::unique_ptr<StatsExporter::Handler> handler) {
-    absl::MutexLock l(&mu_);
-    handlers_.push_back(std::move(handler));
-    if (!thread_started_) {
-      StartExportThread();
-    }
+void StatsExporterImpl::ClearHandlersForTesting() {
+  absl::MutexLock l(&mu_);
+  handlers_.clear();
+}
+
+void StatsExporterImpl::SendToHandlers(const ViewDescriptor& descriptor,
+                                       const ViewData& data)
+    SHARED_LOCKS_REQUIRED(mu_) {
+  for (auto& handler : handlers_) {
+    handler->ExportViewData(descriptor, data);
   }
+}
 
-  std::vector<std::pair<ViewDescriptor, ViewData>> GetViewData() {
-    absl::ReaderMutexLock l(&mu_);
-    std::vector<std::pair<ViewDescriptor, ViewData>> data;
-    data.reserve(views_.size());
-    for (const auto& view : views_) {
-      data.emplace_back(view.second->descriptor(), view.second->GetData());
-    }
-    return data;
-  }
+void StatsExporterImpl::StartExportThread() EXCLUSIVE_LOCKS_REQUIRED(mu_) {
+  t_ = std::thread(&StatsExporterImpl::RunWorkerLoop, this);
+  thread_started_ = true;
+}
 
-  void Export() {
-    absl::ReaderMutexLock l(&mu_);
-    for (const auto& view : views_) {
-      SendToHandlers(view.second->descriptor(), view.second->GetData());
-    }
-  }
-
-  void ClearHandlersForTesting() {
-    absl::MutexLock l(&mu_);
-    handlers_.clear();
-  }
-
- private:
-  StatsExporterImpl() {}
-
-  void SendToHandlers(const ViewDescriptor& descriptor, const ViewData& data)
-      SHARED_LOCKS_REQUIRED(mu_) {
-    for (auto& handler : handlers_) {
-      handler->ExportViewData(descriptor, data);
-    }
-  }
-
-  void StartExportThread() EXCLUSIVE_LOCKS_REQUIRED(mu_) {
-    t_ = std::thread(&StatsExporterImpl::RunWorkerLoop, this);
-    thread_started_ = true;
-  }
-
-  // Loops forever, calling Export() every export_interval_.
-  void RunWorkerLoop() {
-    absl::Time next_export_time = absl::Now() + export_interval_;
-    while (true) {
-      // SleepFor() returns immediately when given a negative duration.
-      absl::SleepFor(next_export_time - absl::Now());
-      // In case the last export took longer than the export interval, we
-      // calculate the next time from now.
-      next_export_time = absl::Now() + export_interval_;
-      Export();
-    }
-  }
-
-  const absl::Duration export_interval_ = absl::Seconds(10);
-
-  mutable absl::Mutex mu_;
-
-  std::vector<std::unique_ptr<StatsExporter::Handler>> handlers_
-      GUARDED_BY(mu_);
-  std::unordered_map<std::string, std::unique_ptr<View>> views_ GUARDED_BY(mu_);
-
-  bool thread_started_ GUARDED_BY(mu_) = false;
-  std::thread t_ GUARDED_BY(mu_);
-};
-
-void StatsExporter::AddView(const ViewDescriptor& view) {
-  if (view.aggregation_window().type() ==
-      AggregationWindow::Type::kCumulative) {
-    StatsExporterImpl::Get()->AddView(view);
-  } else {
-    std::cerr << "Only cumulative views may be registered for export.\n";
+void StatsExporterImpl::RunWorkerLoop() {
+  absl::Time next_export_time = absl::Now() + export_interval_;
+  while (true) {
+    // SleepFor() returns immediately when given a negative duration.
+    absl::SleepFor(next_export_time - absl::Now());
+    // In case the last export took longer than the export interval, we
+    // calculate the next time from now.
+    next_export_time = absl::Now() + export_interval_;
+    Export();
   }
 }
 

--- a/opencensus/stats/internal/stats_exporter_impl.h
+++ b/opencensus/stats/internal/stats_exporter_impl.h
@@ -1,0 +1,73 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <thread>  // NOLINT
+#include <utility>
+#include <vector>
+
+#include "absl/synchronization/mutex.h"
+#include "absl/time/clock.h"
+#include "absl/time/time.h"
+#include "opencensus/stats/internal/aggregation_window.h"
+#include "opencensus/stats/stats_exporter.h"
+#include "opencensus/stats/view_data.h"
+#include "opencensus/stats/view_descriptor.h"
+
+namespace opencensus {
+namespace stats {
+
+class StatsExporterImpl {
+ public:
+  static StatsExporterImpl* Get();
+
+  void AddView(const ViewDescriptor& view);
+
+  void RemoveView(absl::string_view name);
+
+  // Adds a handler, which cannot be subsequently removed (except by
+  // ClearHandlersForTesting()). The background thread is started when the
+  // first handler is registered.
+  void RegisterPushHandler(std::unique_ptr<StatsExporter::Handler> handler);
+
+  std::vector<std::pair<ViewDescriptor, ViewData>> GetViewData();
+
+  void Export();
+
+  void ClearHandlersForTesting();
+
+ private:
+  StatsExporterImpl() {}
+
+  void SendToHandlers(const ViewDescriptor& descriptor, const ViewData& data)
+      SHARED_LOCKS_REQUIRED(mu_);
+
+  void StartExportThread() EXCLUSIVE_LOCKS_REQUIRED(mu_);
+
+  // Loops forever, calling Export() every export_interval_.
+  void RunWorkerLoop();
+
+  const absl::Duration export_interval_ = absl::Seconds(10);
+
+  mutable absl::Mutex mu_;
+
+  std::vector<std::unique_ptr<StatsExporter::Handler>> handlers_
+      GUARDED_BY(mu_);
+  std::unordered_map<std::string, std::unique_ptr<View>> views_ GUARDED_BY(mu_);
+
+  bool thread_started_ GUARDED_BY(mu_) = false;
+  std::thread t_ GUARDED_BY(mu_);
+};
+
+}  // namespace stats
+}  // namespace opencensus

--- a/opencensus/stats/internal/stats_exporter_test.cc
+++ b/opencensus/stats/internal/stats_exporter_test.cc
@@ -100,8 +100,8 @@ class StatsExporterTest : public ::testing::Test {
 
 TEST_F(StatsExporterTest, AddView) {
   MockExporter::Register({descriptor1_, descriptor2_});
-  StatsExporter::AddView(descriptor1_);
-  StatsExporter::AddView(descriptor2_);
+  descriptor1_.RegisterForExport();
+  descriptor2_.RegisterForExport();
   EXPECT_THAT(StatsExporter::GetViewData(),
               ::testing::UnorderedElementsAre(::testing::Key(descriptor1_),
                                               ::testing::Key(descriptor2_)));
@@ -110,9 +110,9 @@ TEST_F(StatsExporterTest, AddView) {
 
 TEST_F(StatsExporterTest, UpdateView) {
   MockExporter::Register({descriptor1_edited_, descriptor2_});
-  StatsExporter::AddView(descriptor1_);
-  StatsExporter::AddView(descriptor2_);
-  StatsExporter::AddView(descriptor1_edited_);
+  descriptor1_.RegisterForExport();
+  descriptor2_.RegisterForExport();
+  descriptor1_edited_.RegisterForExport();
   EXPECT_THAT(
       StatsExporter::GetViewData(),
       ::testing::UnorderedElementsAre(::testing::Key(descriptor1_edited_),
@@ -122,8 +122,8 @@ TEST_F(StatsExporterTest, UpdateView) {
 
 TEST_F(StatsExporterTest, RemoveView) {
   MockExporter::Register({descriptor2_});
-  StatsExporter::AddView(descriptor1_);
-  StatsExporter::AddView(descriptor2_);
+  descriptor1_.RegisterForExport();
+  descriptor2_.RegisterForExport();
   StatsExporter::RemoveView(descriptor1_.name());
   EXPECT_THAT(StatsExporter::GetViewData(),
               ::testing::UnorderedElementsAre(::testing::Key(descriptor2_)));
@@ -133,7 +133,7 @@ TEST_F(StatsExporterTest, RemoveView) {
 TEST_F(StatsExporterTest, MultipleExporters) {
   MockExporter::Register({descriptor1_});
   MockExporter::Register({descriptor1_});
-  StatsExporter::AddView(descriptor1_);
+  descriptor1_.RegisterForExport();
   Export();
 }
 
@@ -142,14 +142,14 @@ TEST_F(StatsExporterTest, IntervalViewRejected) {
   ViewDescriptor interval_descriptor = ViewDescriptor().set_name("interval");
   SetAggregationWindow(AggregationWindow::Interval(absl::Hours(1)),
                        &interval_descriptor);
-  StatsExporter::AddView(interval_descriptor);
+  interval_descriptor.RegisterForExport();
   EXPECT_TRUE(StatsExporter::GetViewData().empty());
   Export();
 }
 
 TEST_F(StatsExporterTest, TimedExport) {
   MockExporter::Register({descriptor1_});
-  StatsExporter::AddView(descriptor1_);
+  descriptor1_.RegisterForExport();
   absl::SleepFor(absl::Seconds(11));
 }
 

--- a/opencensus/stats/internal/view_descriptor.cc
+++ b/opencensus/stats/internal/view_descriptor.cc
@@ -14,11 +14,21 @@
 
 #include "opencensus/stats/view_descriptor.h"
 
+#include <iostream>
+#include <string>
+#include <vector>
+
 #include "absl/memory/memory.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_join.h"
+#include "absl/strings/string_view.h"
 #include "absl/time/time.h"
+#include "opencensus/stats/aggregation.h"
+#include "opencensus/stats/internal/aggregation_window.h"
 #include "opencensus/stats/internal/measure_registry_impl.h"
+#include "opencensus/stats/internal/stats_exporter_impl.h"
+#include "opencensus/stats/measure_descriptor.h"
+#include "opencensus/stats/view.h"
 
 namespace opencensus {
 namespace stats {
@@ -61,6 +71,14 @@ ViewDescriptor& ViewDescriptor::add_column(absl::string_view tag_key) {
 ViewDescriptor& ViewDescriptor::set_description(absl::string_view description) {
   description_ = std::string(description);
   return *this;
+}
+
+void ViewDescriptor::RegisterForExport() const {
+  if (aggregation_window_.type() == AggregationWindow::Type::kCumulative) {
+    StatsExporterImpl::Get()->AddView(*this);
+  } else {
+    std::cerr << "Only cumulative views may be registered for export.\n";
+  }
 }
 
 std::string ViewDescriptor::DebugString() const {

--- a/opencensus/stats/stats_exporter.h
+++ b/opencensus/stats/stats_exporter.h
@@ -30,13 +30,11 @@
 namespace opencensus {
 namespace stats {
 
-// StatsExporter manages views for export, and export handlers.
+// StatsExporter manages views for export, and export handlers. New views can be
+// registered with ViewDescriptor::RegisterForExport().
 // StatsExporter is thread-safe.
 class StatsExporter final {
  public:
-  // Inserts a new view, replacing any existing view with the same name. Only
-  // Cumulative views are supported.
-  static void AddView(const ViewDescriptor& view);
   // Removes the view with 'name' from the registry, if one is registered.
   static void RemoveView(absl::string_view name);
 

--- a/opencensus/stats/view_descriptor.h
+++ b/opencensus/stats/view_descriptor.h
@@ -19,7 +19,6 @@
 #include <string>
 #include <vector>
 
-#include "absl/strings/string_view.h"
 #include "opencensus/stats/aggregation.h"
 #include "opencensus/stats/internal/aggregation_window.h"
 #include "opencensus/stats/measure_descriptor.h"
@@ -33,6 +32,9 @@ namespace stats {
 // TODO: DOCS: Document members.
 class ViewDescriptor final {
  public:
+  //////////////////////////////////////////////////////////////////////////////
+  // View definition
+
   ViewDescriptor();
 
   ViewDescriptor& set_name(absl::string_view name);
@@ -57,6 +59,18 @@ class ViewDescriptor final {
 
   ViewDescriptor& set_description(absl::string_view description);
   const std::string& description() const { return description_; }
+
+  //////////////////////////////////////////////////////////////////////////////
+  // View registration
+
+  // Registers this ViewDescriptor for export, replacing any already registered
+  // view with the same name.; requires that aggregation_window() ==
+  // AggregationWindow::kCumulative() (the default). Future changes to this
+  // ViewDescriptor will not update the registered view.
+  void RegisterForExport() const;
+
+  //////////////////////////////////////////////////////////////////////////////
+  // Utilities
 
   std::string DebugString() const;
 


### PR DESCRIPTION
An API change for consideration: right now, registering a view for export uses a function in StatsExporter, and registering a view for on-task consumption uses the constructor of View. By moving those registration functions to ViewDescriptor, I think it becomes easier to find how to use it by following headers. (It also allows removing StatsExporter from the main user API--it will only be needed for unregistering views and writing exporters.)

WIP: needs implementation, removal/deprecation of competing functions.