### PR TITLE
Define canonical gRPC views.

### DIFF
--- a/opencensus/plugins/grpc/BUILD
+++ b/opencensus/plugins/grpc/BUILD
@@ -30,6 +30,7 @@ cc_library(
         "internal/grpc_plugin.cc",
         "internal/measures.cc",
         "internal/server_filter.cc",
+        "internal/views.cc",
     ],
     hdrs = [
         "grpc_plugin.h",

--- a/opencensus/plugins/grpc/grpc_plugin.h
+++ b/opencensus/plugins/grpc/grpc_plugin.h
@@ -16,6 +16,7 @@
 #define OPENCENSUS_PLUGINS_GRPC_GRPC_PLUGIN_H_
 
 #include "absl/strings/string_view.h"
+#include "opencensus/stats/stats.h"
 #include "opencensus/trace/span.h"
 
 namespace grpc {
@@ -28,6 +29,12 @@ namespace opencensus {
 // RPCs. This must be called before any views are created on the measures
 // defined below.
 void RegisterGrpcPlugin();
+
+// Registers the cumulative gRPC views so that they will be exported by any
+// registered stats exporter.
+// For on-task stats, construct a View using the ViewDescriptors below.
+// Experimental: These view definitions are subject to change.
+void ExperimentalRegisterGrpcViewsForExport();
 
 // Returns the tracing Span for the current RPC.
 opencensus::trace::Span GetSpanFromServerContext(grpc::ServerContext* context);
@@ -57,6 +64,65 @@ extern const absl::string_view kRpcServerStartedCountMeasureName;
 extern const absl::string_view kRpcServerFinishedCountMeasureName;
 extern const absl::string_view kRpcServerRequestCountMeasureName;
 extern const absl::string_view kRpcServerResponseCountMeasureName;
+
+// Canonical gRPC view definitions.
+// These view definitions are subject to change.
+const stats::ViewDescriptor& ClientErrorCountCumulative();
+const stats::ViewDescriptor& ClientRequestBytesCumulative();
+const stats::ViewDescriptor& ClientResponseBytesCumulative();
+const stats::ViewDescriptor& ClientRoundtripLatencyCumulative();
+const stats::ViewDescriptor& ClientServerElapsedTimeCumulative();
+const stats::ViewDescriptor& ClientStartedCountCumulative();
+const stats::ViewDescriptor& ClientFinishedCountCumulative();
+const stats::ViewDescriptor& ClientRequestCountCumulative();
+const stats::ViewDescriptor& ClientResponseCountCumulative();
+
+const stats::ViewDescriptor& ServerErrorCountCumulative();
+const stats::ViewDescriptor& ServerRequestBytesCumulative();
+const stats::ViewDescriptor& ServerResponseBytesCumulative();
+const stats::ViewDescriptor& ServerServerElapsedTimeCumulative();
+const stats::ViewDescriptor& ServerStartedCountCumulative();
+const stats::ViewDescriptor& ServerFinishedCountCumulative();
+const stats::ViewDescriptor& ServerRequestCountCumulative();
+const stats::ViewDescriptor& ServerResponseCountCumulative();
+
+const stats::ViewDescriptor& ClientErrorCountMinute();
+const stats::ViewDescriptor& ClientRequestBytesMinute();
+const stats::ViewDescriptor& ClientResponseBytesMinute();
+const stats::ViewDescriptor& ClientRoundtripLatencyMinute();
+const stats::ViewDescriptor& ClientServerElapsedTimeMinute();
+const stats::ViewDescriptor& ClientStartedCountMinute();
+const stats::ViewDescriptor& ClientFinishedCountMinute();
+const stats::ViewDescriptor& ClientRequestCountMinute();
+const stats::ViewDescriptor& ClientResponseCountMinute();
+
+const stats::ViewDescriptor& ServerErrorCountMinute();
+const stats::ViewDescriptor& ServerRequestBytesMinute();
+const stats::ViewDescriptor& ServerResponseBytesMinute();
+const stats::ViewDescriptor& ServerServerElapsedTimeMinute();
+const stats::ViewDescriptor& ServerStartedCountMinute();
+const stats::ViewDescriptor& ServerFinishedCountMinute();
+const stats::ViewDescriptor& ServerRequestCountMinute();
+const stats::ViewDescriptor& ServerResponseCountMinute();
+
+const stats::ViewDescriptor& ClientErrorCountHour();
+const stats::ViewDescriptor& ClientRequestBytesHour();
+const stats::ViewDescriptor& ClientResponseBytesHour();
+const stats::ViewDescriptor& ClientRoundtripLatencyHour();
+const stats::ViewDescriptor& ClientServerElapsedTimeHour();
+const stats::ViewDescriptor& ClientStartedCountHour();
+const stats::ViewDescriptor& ClientFinishedCountHour();
+const stats::ViewDescriptor& ClientRequestCountHour();
+const stats::ViewDescriptor& ClientResponseCountHour();
+
+const stats::ViewDescriptor& ServerErrorCountHour();
+const stats::ViewDescriptor& ServerRequestBytesHour();
+const stats::ViewDescriptor& ServerResponseBytesHour();
+const stats::ViewDescriptor& ServerServerElapsedTimeHour();
+const stats::ViewDescriptor& ServerStartedCountHour();
+const stats::ViewDescriptor& ServerFinishedCountHour();
+const stats::ViewDescriptor& ServerRequestCountHour();
+const stats::ViewDescriptor& ServerResponseCountHour();
 
 }  // namespace opencensus
 

--- a/opencensus/plugins/grpc/internal/stats_plugin_end2end_test.cc
+++ b/opencensus/plugins/grpc/internal/stats_plugin_end2end_test.cc
@@ -158,38 +158,10 @@ TEST_F(StatsPluginEnd2EndTest, ErrorCount) {
 }
 
 TEST_F(StatsPluginEnd2EndTest, RequestResponseBytes) {
-  const auto client_request_bytes_descriptor =
-      stats::ViewDescriptor()
-          .set_measure(kRpcClientRequestBytesMeasureName)
-          .set_name("client_request_bytes")
-          .set_aggregation(stats::Aggregation::Distribution(
-              stats::BucketBoundaries::Explicit({})))
-          .add_column(kMethodTagKey);
-  stats::View client_request_bytes_view(client_request_bytes_descriptor);
-  const auto client_response_bytes_descriptor =
-      stats::ViewDescriptor()
-          .set_measure(kRpcClientResponseBytesMeasureName)
-          .set_name("client_response_bytes")
-          .set_aggregation(stats::Aggregation::Distribution(
-              stats::BucketBoundaries::Explicit({})))
-          .add_column(kMethodTagKey);
-  stats::View client_response_bytes_view(client_response_bytes_descriptor);
-  const auto server_request_bytes_descriptor =
-      stats::ViewDescriptor()
-          .set_measure(kRpcServerRequestBytesMeasureName)
-          .set_name("server_request_bytes")
-          .set_aggregation(stats::Aggregation::Distribution(
-              stats::BucketBoundaries::Explicit({})))
-          .add_column(kMethodTagKey);
-  stats::View server_request_bytes_view(server_request_bytes_descriptor);
-  const auto server_response_bytes_descriptor =
-      stats::ViewDescriptor()
-          .set_measure(kRpcServerResponseBytesMeasureName)
-          .set_name("server_response_bytes")
-          .set_aggregation(stats::Aggregation::Distribution(
-              stats::BucketBoundaries::Explicit({})))
-          .add_column(kMethodTagKey);
-  stats::View server_response_bytes_view(server_response_bytes_descriptor);
+  stats::View client_request_bytes_view(ClientRequestBytesCumulative());
+  stats::View client_response_bytes_view(ClientResponseBytesCumulative());
+  stats::View server_request_bytes_view(ServerRequestBytesCumulative());
+  stats::View server_response_bytes_view(ServerResponseBytesCumulative());
 
   {
     EchoRequest request;
@@ -201,72 +173,42 @@ TEST_F(StatsPluginEnd2EndTest, RequestResponseBytes) {
     EXPECT_EQ("foo", response.message());
   }
 
-  const auto client_request_bytes_data =
-      client_request_bytes_view.GetData().distribution_data();
-  ASSERT_EQ(1, client_request_bytes_data.size());
-  const auto client_request_bytes =
-      client_request_bytes_data.find({method_name_});
-  ASSERT_NE(client_request_bytes, client_request_bytes_data.end());
-  EXPECT_EQ(1, client_request_bytes->second.count());
-  EXPECT_GT(client_request_bytes->second.mean(), 0);
-
-  const auto client_response_bytes_data =
-      client_response_bytes_view.GetData().distribution_data();
-  ASSERT_EQ(1, client_response_bytes_data.size());
-  const auto client_response_bytes =
-      client_response_bytes_data.find({method_name_});
-  ASSERT_NE(client_response_bytes, client_response_bytes_data.end());
-  EXPECT_EQ(1, client_response_bytes->second.count());
-  EXPECT_GT(client_response_bytes->second.mean(), 0);
-
-  const auto server_request_bytes_data =
-      server_request_bytes_view.GetData().distribution_data();
-  ASSERT_EQ(1, server_request_bytes_data.size());
-  const auto server_request_bytes =
-      server_request_bytes_data.find({method_name_});
-  ASSERT_NE(server_request_bytes, server_request_bytes_data.end());
-  EXPECT_EQ(1, server_request_bytes->second.count());
-  EXPECT_DOUBLE_EQ(server_request_bytes->second.mean(),
-                   client_request_bytes->second.mean());
-
-  const auto server_response_bytes_data =
-      server_response_bytes_view.GetData().distribution_data();
-  ASSERT_EQ(1, server_response_bytes_data.size());
-  const auto server_response_bytes =
-      server_response_bytes_data.find({method_name_});
-  ASSERT_NE(server_response_bytes, server_response_bytes_data.end());
-  EXPECT_EQ(1, server_response_bytes->second.count());
-  EXPECT_DOUBLE_EQ(server_response_bytes->second.mean(),
-                   client_response_bytes->second.mean());
+  EXPECT_THAT(
+      client_request_bytes_view.GetData().distribution_data(),
+      ::testing::UnorderedElementsAre(::testing::Pair(
+          ::testing::ElementsAre(method_name_),
+          ::testing::AllOf(::testing::Property(&stats::Distribution::count, 1),
+                           ::testing::Property(&stats::Distribution::mean,
+                                               ::testing::Gt(0.0))))));
+  EXPECT_THAT(
+      client_response_bytes_view.GetData().distribution_data(),
+      ::testing::UnorderedElementsAre(::testing::Pair(
+          ::testing::ElementsAre(method_name_),
+          ::testing::AllOf(::testing::Property(&stats::Distribution::count, 1),
+                           ::testing::Property(&stats::Distribution::mean,
+                                               ::testing::Gt(0.0))))));
+  EXPECT_THAT(
+      server_request_bytes_view.GetData().distribution_data(),
+      ::testing::UnorderedElementsAre(::testing::Pair(
+          ::testing::ElementsAre(method_name_),
+          ::testing::AllOf(::testing::Property(&stats::Distribution::count, 1),
+                           ::testing::Property(&stats::Distribution::mean,
+                                               ::testing::Gt(0.0))))));
+  EXPECT_THAT(
+      server_response_bytes_view.GetData().distribution_data(),
+      ::testing::UnorderedElementsAre(::testing::Pair(
+          ::testing::ElementsAre(method_name_),
+          ::testing::AllOf(::testing::Property(&stats::Distribution::count, 1),
+                           ::testing::Property(&stats::Distribution::mean,
+                                               ::testing::Gt(0.0))))));
 }
 
 TEST_F(StatsPluginEnd2EndTest, Latency) {
-  const auto client_latency_descriptor =
-      stats::ViewDescriptor()
-          .set_measure(kRpcClientRoundtripLatencyMeasureName)
-          .set_name("client_latency")
-          .set_aggregation(stats::Aggregation::Distribution(
-              stats::BucketBoundaries::Explicit({})))
-          .add_column(kMethodTagKey);
-  stats::View client_latency_view(client_latency_descriptor);
-  const auto client_server_elapsed_time_descriptor =
-      stats::ViewDescriptor()
-          .set_measure(kRpcClientServerElapsedTimeMeasureName)
-          .set_name("client_server_elapsed_time")
-          .set_aggregation(stats::Aggregation::Distribution(
-              stats::BucketBoundaries::Explicit({})))
-          .add_column(kMethodTagKey);
+  stats::View client_latency_view(ClientRoundtripLatencyCumulative());
   stats::View client_server_elapsed_time_view(
-      client_server_elapsed_time_descriptor);
-  const auto server_server_elapsed_time_descriptor =
-      stats::ViewDescriptor()
-          .set_measure(kRpcServerServerElapsedTimeMeasureName)
-          .set_name("server_server_elapsed_time")
-          .set_aggregation(stats::Aggregation::Distribution(
-              stats::BucketBoundaries::Explicit({})))
-          .add_column(kMethodTagKey);
+      ClientServerElapsedTimeCumulative());
   stats::View server_server_elapsed_time_view(
-      server_server_elapsed_time_descriptor);
+      ServerServerElapsedTimeCumulative());
 
   const absl::Time start_time = absl::Now();
   {
@@ -282,69 +224,52 @@ TEST_F(StatsPluginEnd2EndTest, Latency) {
   // entire time spent making the RPC.
   const double max_time = absl::ToDoubleMilliseconds(absl::Now() - start_time);
 
-  const auto client_latency_data =
-      client_latency_view.GetData().distribution_data();
-  ASSERT_EQ(1, client_latency_data.size());
-  const auto client_latency = client_latency_data.find({method_name_});
-  ASSERT_NE(client_latency, client_latency_data.end());
-  EXPECT_EQ(1, client_latency->second.count());
-  EXPECT_GT(client_latency->second.mean(), 0);
-  EXPECT_LT(client_latency->second.mean(), max_time);
+  EXPECT_THAT(
+      client_latency_view.GetData().distribution_data(),
+      ::testing::UnorderedElementsAre(::testing::Pair(
+          ::testing::ElementsAre(method_name_),
+          ::testing::AllOf(::testing::Property(&stats::Distribution::count, 1),
+                           ::testing::Property(&stats::Distribution::mean,
+                                               ::testing::Gt(0.0)),
+                           ::testing::Property(&stats::Distribution::mean,
+                                               ::testing::Lt(max_time))))));
 
-  const auto client_server_elapsed_time_data =
-      client_server_elapsed_time_view.GetData().distribution_data();
-  ASSERT_EQ(1, client_server_elapsed_time_data.size());
-  const auto client_server_elapsed_time =
-      client_server_elapsed_time_data.find({method_name_});
-  ASSERT_NE(client_server_elapsed_time, client_server_elapsed_time_data.end());
-  EXPECT_EQ(1, client_server_elapsed_time->second.count());
-  EXPECT_GT(client_server_elapsed_time->second.mean(), 0);
   // Elapsed time is a subinterval of total latency.
-  EXPECT_LT(client_server_elapsed_time->second.mean(),
-            client_latency->second.mean());
+  const auto client_latency = client_latency_view.GetData()
+                                  .distribution_data()
+                                  .find({method_name_})
+                                  ->second.mean();
+  EXPECT_THAT(client_server_elapsed_time_view.GetData().distribution_data(),
+              ::testing::UnorderedElementsAre(::testing::Pair(
+                  ::testing::ElementsAre(method_name_),
+                  ::testing::AllOf(
+                      ::testing::Property(&stats::Distribution::count, 1),
+                      ::testing::Property(&stats::Distribution::mean,
+                                          ::testing::Gt(0.0)),
+                      ::testing::Property(&stats::Distribution::mean,
+                                          ::testing::Lt(client_latency))))));
 
-  const auto server_server_elapsed_time_data =
-      server_server_elapsed_time_view.GetData().distribution_data();
-  ASSERT_EQ(1, server_server_elapsed_time_data.size());
-  const auto server_server_elapsed_time =
-      server_server_elapsed_time_data.find({method_name_});
-  ASSERT_NE(server_server_elapsed_time, server_server_elapsed_time_data.end());
-  EXPECT_EQ(1, server_server_elapsed_time->second.count());
   // client server elapsed time should be the same value propagated to the
   // client.
-  EXPECT_DOUBLE_EQ(server_server_elapsed_time->second.mean(),
-                   client_server_elapsed_time->second.mean());
+  const auto client_elapsed_time = client_server_elapsed_time_view.GetData()
+                                       .distribution_data()
+                                       .find({method_name_})
+                                       ->second.mean();
+  EXPECT_THAT(
+      server_server_elapsed_time_view.GetData().distribution_data(),
+      ::testing::UnorderedElementsAre(::testing::Pair(
+          ::testing::ElementsAre(method_name_),
+          ::testing::AllOf(
+              ::testing::Property(&stats::Distribution::count, 1),
+              ::testing::Property(&stats::Distribution::mean,
+                                  ::testing::DoubleEq(client_elapsed_time))))));
 }
 
 TEST_F(StatsPluginEnd2EndTest, StartFinishCount) {
-  const auto client_started_count_descriptor =
-      stats::ViewDescriptor()
-          .set_measure(kRpcClientStartedCountMeasureName)
-          .set_name("client_started_count")
-          .set_aggregation(stats::Aggregation::Sum())
-          .add_column(kMethodTagKey);
-  stats::View client_started_count_view(client_started_count_descriptor);
-  const auto client_finished_count_descriptor =
-      stats::ViewDescriptor()
-          .set_measure(kRpcClientFinishedCountMeasureName)
-          .set_name("client_finished_count")
-          .set_aggregation(stats::Aggregation::Sum())
-          .add_column(kMethodTagKey);
-  stats::View client_finished_count_view(client_finished_count_descriptor);
-  const auto server_started_count_descriptor =
-      stats::ViewDescriptor()
-          .set_measure(kRpcServerStartedCountMeasureName)
-          .set_name("server_started_count")
-          .set_aggregation(stats::Aggregation::Sum())
-          .add_column(kMethodTagKey);
-  stats::View server_started_count_view(server_started_count_descriptor);
-  const auto server_finished_count_descriptor =
-      stats::ViewDescriptor()
-          .set_measure(kRpcServerFinishedCountMeasureName)
-          .set_name("server_finished_count")
-          .set_aggregation(stats::Aggregation::Sum())
-          .add_column(kMethodTagKey);
-  stats::View server_finished_count_view(server_finished_count_descriptor);
+  stats::View client_started_count_view(ClientStartedCountCumulative());
+  stats::View client_finished_count_view(ClientFinishedCountCumulative());
+  stats::View server_started_count_view(ServerStartedCountCumulative());
+  stats::View server_finished_count_view(ServerFinishedCountCumulative());
 
   EchoRequest request;
   request.set_message("foo");
@@ -375,34 +300,10 @@ TEST_F(StatsPluginEnd2EndTest, StartFinishCount) {
 
 TEST_F(StatsPluginEnd2EndTest, RequestResponseCount) {
   // TODO: Use streaming RPCs.
-  const auto client_request_count_descriptor =
-      stats::ViewDescriptor()
-          .set_measure(kRpcClientRequestCountMeasureName)
-          .set_name("client_request_count")
-          .set_aggregation(stats::Aggregation::Sum())
-          .add_column(kMethodTagKey);
-  stats::View client_request_count_view(client_request_count_descriptor);
-  const auto client_response_count_descriptor =
-      stats::ViewDescriptor()
-          .set_measure(kRpcClientResponseCountMeasureName)
-          .set_name("client_response_count")
-          .set_aggregation(stats::Aggregation::Sum())
-          .add_column(kMethodTagKey);
-  stats::View client_response_count_view(client_response_count_descriptor);
-  const auto server_request_count_descriptor =
-      stats::ViewDescriptor()
-          .set_measure(kRpcServerRequestCountMeasureName)
-          .set_name("server_request_count")
-          .set_aggregation(stats::Aggregation::Sum())
-          .add_column(kMethodTagKey);
-  stats::View server_request_count_view(server_request_count_descriptor);
-  const auto server_response_count_descriptor =
-      stats::ViewDescriptor()
-          .set_measure(kRpcServerResponseCountMeasureName)
-          .set_name("server_response_count")
-          .set_aggregation(stats::Aggregation::Sum())
-          .add_column(kMethodTagKey);
-  stats::View server_response_count_view(server_response_count_descriptor);
+  stats::View client_request_count_view(ClientRequestCountCumulative());
+  stats::View client_response_count_view(ClientResponseCountCumulative());
+  stats::View server_request_count_view(ServerRequestCountCumulative());
+  stats::View server_response_count_view(ServerResponseCountCumulative());
 
   EchoRequest request;
   request.set_message("foo");
@@ -416,18 +317,34 @@ TEST_F(StatsPluginEnd2EndTest, RequestResponseCount) {
       EXPECT_EQ("foo", response.message());
     }
 
-    EXPECT_THAT(client_request_count_view.GetData().double_data(),
+    EXPECT_THAT(client_request_count_view.GetData().distribution_data(),
                 ::testing::UnorderedElementsAre(::testing::Pair(
-                    ::testing::ElementsAre(method_name_), i + 1)));
-    EXPECT_THAT(client_response_count_view.GetData().double_data(),
+                    ::testing::ElementsAre(method_name_),
+                    ::testing::AllOf(
+                        ::testing::Property(&stats::Distribution::count, i + 1),
+                        ::testing::Property(&stats::Distribution::mean,
+                                            ::testing::DoubleEq(1.0))))));
+    EXPECT_THAT(client_response_count_view.GetData().distribution_data(),
                 ::testing::UnorderedElementsAre(::testing::Pair(
-                    ::testing::ElementsAre(method_name_), i + 1)));
-    EXPECT_THAT(server_request_count_view.GetData().double_data(),
+                    ::testing::ElementsAre(method_name_),
+                    ::testing::AllOf(
+                        ::testing::Property(&stats::Distribution::count, i + 1),
+                        ::testing::Property(&stats::Distribution::mean,
+                                            ::testing::DoubleEq(1.0))))));
+    EXPECT_THAT(server_request_count_view.GetData().distribution_data(),
                 ::testing::UnorderedElementsAre(::testing::Pair(
-                    ::testing::ElementsAre(method_name_), i + 1)));
-    EXPECT_THAT(server_response_count_view.GetData().double_data(),
+                    ::testing::ElementsAre(method_name_),
+                    ::testing::AllOf(
+                        ::testing::Property(&stats::Distribution::count, i + 1),
+                        ::testing::Property(&stats::Distribution::mean,
+                                            ::testing::DoubleEq(1.0))))));
+    EXPECT_THAT(server_response_count_view.GetData().distribution_data(),
                 ::testing::UnorderedElementsAre(::testing::Pair(
-                    ::testing::ElementsAre(method_name_), i + 1)));
+                    ::testing::ElementsAre(method_name_),
+                    ::testing::AllOf(
+                        ::testing::Property(&stats::Distribution::count, i + 1),
+                        ::testing::Property(&stats::Distribution::mean,
+                                            ::testing::DoubleEq(1.0))))));
   }
 }
 

--- a/opencensus/plugins/grpc/internal/views.cc
+++ b/opencensus/plugins/grpc/internal/views.cc
@@ -1,0 +1,608 @@
+// Copyright 2018 OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "opencensus/plugins/grpc/grpc_plugin.h"
+
+#include "absl/time/time.h"
+#include "opencensus/stats/internal/aggregation_window.h"
+#include "opencensus/stats/internal/set_aggregation_window.h"
+#include "opencensus/stats/stats.h"
+
+namespace opencensus {
+
+// These measure definitions should be kept in sync across opencensus
+// implementations.
+
+namespace {
+
+stats::Aggregation BytesDistributionAggregation() {
+  return stats::Aggregation::Distribution(stats::BucketBoundaries::Explicit(
+      {0.0, 1024.0, 2048.0, 4096.0, 16384.0, 65536.0, 262144.0, 1048576.0,
+       4194304.0, 16777216.0, 67108864.0, 268435456.0, 1073741824.0,
+       4294967296.0}));
+}
+
+stats::Aggregation MillisDistributionAggregation() {
+  return stats::Aggregation::Distribution(stats::BucketBoundaries::Explicit(
+      {0.0,   1.0,    2.0,    3.0,    4.0,     5.0,     6.0,     8.0,     10.0,
+       13.0,  16.0,   20.0,   25.0,   30.0,    40.0,    50.0,    65.0,    80.0,
+       100.0, 130.0,  160.0,  200.0,  250.0,   300.0,   400.0,   500.0,   650.0,
+       800.0, 1000.0, 2000.0, 5000.0, 10000.0, 20000.0, 50000.0, 100000.0}));
+}
+
+stats::Aggregation CountDistributionAggregation() {
+  return stats::Aggregation::Distribution(
+      stats::BucketBoundaries::Exponential(17, 1.0, 2.0));
+}
+
+stats::ViewDescriptor MinuteDescriptor() {
+  auto descriptor = stats::ViewDescriptor();
+  SetAggregationWindow(stats::AggregationWindow::Interval(absl::Minutes(1)),
+                       &descriptor);
+  return descriptor;
+}
+
+stats::ViewDescriptor HourDescriptor() {
+  auto descriptor = stats::ViewDescriptor();
+  SetAggregationWindow(stats::AggregationWindow::Interval(absl::Hours(1)),
+                       &descriptor);
+  return descriptor;
+}
+
+}  // namespace
+
+void ExperimentalRegisterGrpcViewsForExport() {
+  ClientErrorCountCumulative().RegisterForExport();
+  ClientRequestBytesCumulative().RegisterForExport();
+  ClientResponseBytesCumulative().RegisterForExport();
+  ClientRoundtripLatencyCumulative().RegisterForExport();
+  ClientServerElapsedTimeCumulative().RegisterForExport();
+  ClientStartedCountCumulative().RegisterForExport();
+  ClientFinishedCountCumulative().RegisterForExport();
+  ClientRequestCountCumulative().RegisterForExport();
+  ClientResponseCountCumulative().RegisterForExport();
+
+  ServerErrorCountCumulative().RegisterForExport();
+  ServerRequestBytesCumulative().RegisterForExport();
+  ServerResponseBytesCumulative().RegisterForExport();
+  ServerServerElapsedTimeCumulative().RegisterForExport();
+  ServerStartedCountCumulative().RegisterForExport();
+  ServerFinishedCountCumulative().RegisterForExport();
+  ServerRequestCountCumulative().RegisterForExport();
+  ServerResponseCountCumulative().RegisterForExport();
+}
+
+// client cumulative
+const stats::ViewDescriptor& ClientErrorCountCumulative() {
+  const static stats::ViewDescriptor descriptor =
+      stats::ViewDescriptor()
+          .set_name("grpc.io/client/error_count/cumulative")
+          .set_measure(kRpcClientErrorCountMeasureName)
+          .set_aggregation(stats::Aggregation::Sum())
+          .add_column(kMethodTagKey)
+          .add_column(kStatusTagKey);
+  return descriptor;
+}
+
+const stats::ViewDescriptor& ClientRequestBytesCumulative() {
+  const static stats::ViewDescriptor descriptor =
+      stats::ViewDescriptor()
+          .set_name("grpc.io/client/request_bytes/cumulative")
+          .set_measure(kRpcClientRequestBytesMeasureName)
+          .set_aggregation(BytesDistributionAggregation())
+          .add_column(kMethodTagKey);
+  return descriptor;
+}
+
+const stats::ViewDescriptor& ClientResponseBytesCumulative() {
+  const static stats::ViewDescriptor descriptor =
+      stats::ViewDescriptor()
+          .set_name("grpc.io/client/response_bytes/cumulative")
+          .set_measure(kRpcClientResponseBytesMeasureName)
+          .set_aggregation(BytesDistributionAggregation())
+          .add_column(kMethodTagKey);
+  return descriptor;
+}
+
+const stats::ViewDescriptor& ClientRoundtripLatencyCumulative() {
+  const static stats::ViewDescriptor descriptor =
+      stats::ViewDescriptor()
+          .set_name("grpc.io/client/roundtrip_latency/cumulative")
+          .set_measure(kRpcClientRoundtripLatencyMeasureName)
+          .set_aggregation(MillisDistributionAggregation())
+          .add_column(kMethodTagKey);
+  return descriptor;
+}
+
+const stats::ViewDescriptor& ClientServerElapsedTimeCumulative() {
+  const static stats::ViewDescriptor descriptor =
+      stats::ViewDescriptor()
+          .set_name("grpc.io/client/server_elapsed_time/cumulative")
+          .set_measure(kRpcClientServerElapsedTimeMeasureName)
+          .set_aggregation(MillisDistributionAggregation())
+          .add_column(kMethodTagKey);
+  return descriptor;
+}
+
+const stats::ViewDescriptor& ClientStartedCountCumulative() {
+  const static stats::ViewDescriptor descriptor =
+      stats::ViewDescriptor()
+          .set_name("grpc.io/client/started_count/cumulative")
+          .set_measure(kRpcClientStartedCountMeasureName)
+          .set_aggregation(stats::Aggregation::Sum())
+          .add_column(kMethodTagKey);
+  return descriptor;
+}
+
+const stats::ViewDescriptor& ClientFinishedCountCumulative() {
+  const static stats::ViewDescriptor descriptor =
+      stats::ViewDescriptor()
+          .set_name("grpc.io/client/finished_count/cumulative")
+          .set_measure(kRpcClientFinishedCountMeasureName)
+          .set_aggregation(stats::Aggregation::Sum())
+          .add_column(kMethodTagKey);
+  return descriptor;
+}
+
+const stats::ViewDescriptor& ClientRequestCountCumulative() {
+  const static stats::ViewDescriptor descriptor =
+      stats::ViewDescriptor()
+          .set_name("grpc.io/client/request_count/cumulative")
+          .set_measure(kRpcClientRequestCountMeasureName)
+          .set_aggregation(CountDistributionAggregation())
+          .add_column(kMethodTagKey);
+  return descriptor;
+}
+
+const stats::ViewDescriptor& ClientResponseCountCumulative() {
+  const static stats::ViewDescriptor descriptor =
+      stats::ViewDescriptor()
+          .set_name("grpc.io/client/response_count/cumulative")
+          .set_measure(kRpcClientResponseCountMeasureName)
+          .set_aggregation(CountDistributionAggregation())
+          .add_column(kMethodTagKey);
+  return descriptor;
+}
+
+// server cumulative
+const stats::ViewDescriptor& ServerErrorCountCumulative() {
+  const static stats::ViewDescriptor descriptor =
+      MinuteDescriptor()
+          .set_name("grpc.io/server/error_count/cumulative")
+          .set_measure(kRpcServerErrorCountMeasureName)
+          .set_aggregation(stats::Aggregation::Sum())
+          .add_column(kMethodTagKey)
+          .add_column(kStatusTagKey);
+  return descriptor;
+}
+
+const stats::ViewDescriptor& ServerRequestBytesCumulative() {
+  const static stats::ViewDescriptor descriptor =
+      MinuteDescriptor()
+          .set_name("grpc.io/server/request_bytes/cumulative")
+          .set_measure(kRpcServerRequestBytesMeasureName)
+          .set_aggregation(BytesDistributionAggregation())
+          .add_column(kMethodTagKey);
+  return descriptor;
+}
+
+const stats::ViewDescriptor& ServerResponseBytesCumulative() {
+  const static stats::ViewDescriptor descriptor =
+      MinuteDescriptor()
+          .set_name("grpc.io/server/response_bytes/cumulative")
+          .set_measure(kRpcServerResponseBytesMeasureName)
+          .set_aggregation(BytesDistributionAggregation())
+          .add_column(kMethodTagKey);
+  return descriptor;
+}
+
+const stats::ViewDescriptor& ServerServerElapsedTimeCumulative() {
+  const static stats::ViewDescriptor descriptor =
+      MinuteDescriptor()
+          .set_name("grpc.io/server/elapsed_time/cumulative")
+          .set_measure(kRpcServerServerElapsedTimeMeasureName)
+          .set_aggregation(MillisDistributionAggregation())
+          .add_column(kMethodTagKey);
+  return descriptor;
+}
+
+const stats::ViewDescriptor& ServerStartedCountCumulative() {
+  const static stats::ViewDescriptor descriptor =
+      MinuteDescriptor()
+          .set_name("grpc.io/server/started_count/cumulative")
+          .set_measure(kRpcServerStartedCountMeasureName)
+          .set_aggregation(stats::Aggregation::Sum())
+          .add_column(kMethodTagKey);
+  return descriptor;
+}
+
+const stats::ViewDescriptor& ServerFinishedCountCumulative() {
+  const static stats::ViewDescriptor descriptor =
+      MinuteDescriptor()
+          .set_name("grpc.io/server/finished_count/cumulative")
+          .set_measure(kRpcServerFinishedCountMeasureName)
+          .set_aggregation(stats::Aggregation::Sum())
+          .add_column(kMethodTagKey);
+  return descriptor;
+}
+
+const stats::ViewDescriptor& ServerRequestCountCumulative() {
+  const static stats::ViewDescriptor descriptor =
+      MinuteDescriptor()
+          .set_name("grpc.io/server/request_count/cumulative")
+          .set_measure(kRpcServerRequestCountMeasureName)
+          .set_aggregation(CountDistributionAggregation())
+          .add_column(kMethodTagKey);
+  return descriptor;
+}
+
+const stats::ViewDescriptor& ServerResponseCountCumulative() {
+  const static stats::ViewDescriptor descriptor =
+      MinuteDescriptor()
+          .set_name("grpc.io/server/response_count/cumulative")
+          .set_measure(kRpcServerResponseCountMeasureName)
+          .set_aggregation(CountDistributionAggregation())
+          .add_column(kMethodTagKey);
+  return descriptor;
+}
+
+// client minute
+const stats::ViewDescriptor& ClientErrorCountMinute() {
+  const static stats::ViewDescriptor descriptor =
+      MinuteDescriptor()
+          .set_name("grpc.io/client/error_count/minute")
+          .set_measure(kRpcClientErrorCountMeasureName)
+          .set_aggregation(stats::Aggregation::Sum())
+          .add_column(kMethodTagKey)
+          .add_column(kStatusTagKey);
+  return descriptor;
+}
+
+const stats::ViewDescriptor& ClientRequestBytesMinute() {
+  const static stats::ViewDescriptor descriptor =
+      MinuteDescriptor()
+          .set_name("grpc.io/client/request_bytes/minute")
+          .set_measure(kRpcClientRequestBytesMeasureName)
+          .set_aggregation(BytesDistributionAggregation())
+          .add_column(kMethodTagKey);
+  return descriptor;
+}
+
+const stats::ViewDescriptor& ClientResponseBytesMinute() {
+  const static stats::ViewDescriptor descriptor =
+      MinuteDescriptor()
+          .set_name("grpc.io/client/response_bytes/minute")
+          .set_measure(kRpcClientResponseBytesMeasureName)
+          .set_aggregation(BytesDistributionAggregation())
+          .add_column(kMethodTagKey);
+  return descriptor;
+}
+
+const stats::ViewDescriptor& ClientRoundtripLatencyMinute() {
+  const static stats::ViewDescriptor descriptor =
+      MinuteDescriptor()
+          .set_name("grpc.io/client/roundtrip_latency/minute")
+          .set_measure(kRpcClientRoundtripLatencyMeasureName)
+          .set_aggregation(MillisDistributionAggregation())
+          .add_column(kMethodTagKey);
+  return descriptor;
+}
+
+const stats::ViewDescriptor& ClientServerElapsedTimeMinute() {
+  const static stats::ViewDescriptor descriptor =
+      MinuteDescriptor()
+          .set_name("grpc.io/client/server_elapsed_time/minute")
+          .set_measure(kRpcClientServerElapsedTimeMeasureName)
+          .set_aggregation(MillisDistributionAggregation())
+          .add_column(kMethodTagKey);
+  return descriptor;
+}
+
+const stats::ViewDescriptor& ClientStartedCountMinute() {
+  const static stats::ViewDescriptor descriptor =
+      MinuteDescriptor()
+          .set_name("grpc.io/client/started_count/minute")
+          .set_measure(kRpcClientStartedCountMeasureName)
+          .set_aggregation(stats::Aggregation::Sum())
+          .add_column(kMethodTagKey);
+  return descriptor;
+}
+
+const stats::ViewDescriptor& ClientFinishedCountMinute() {
+  const static stats::ViewDescriptor descriptor =
+      MinuteDescriptor()
+          .set_name("grpc.io/client/finished_count/minute")
+          .set_measure(kRpcClientFinishedCountMeasureName)
+          .set_aggregation(stats::Aggregation::Sum())
+          .add_column(kMethodTagKey);
+  return descriptor;
+}
+
+const stats::ViewDescriptor& ClientRequestCountMinute() {
+  const static stats::ViewDescriptor descriptor =
+      MinuteDescriptor()
+          .set_name("grpc.io/client/request_count/minute")
+          .set_measure(kRpcClientRequestCountMeasureName)
+          .set_aggregation(CountDistributionAggregation())
+          .add_column(kMethodTagKey);
+  return descriptor;
+}
+
+const stats::ViewDescriptor& ClientResponseCountMinute() {
+  const static stats::ViewDescriptor descriptor =
+      MinuteDescriptor()
+          .set_name("grpc.io/client/response_count/minute")
+          .set_measure(kRpcClientResponseCountMeasureName)
+          .set_aggregation(CountDistributionAggregation())
+          .add_column(kMethodTagKey);
+  return descriptor;
+}
+
+// server minute
+const stats::ViewDescriptor& ServerErrorCountMinute() {
+  const static stats::ViewDescriptor descriptor =
+      MinuteDescriptor()
+          .set_name("grpc.io/server/error_count/minute")
+          .set_measure(kRpcServerErrorCountMeasureName)
+          .set_aggregation(stats::Aggregation::Sum())
+          .add_column(kMethodTagKey)
+          .add_column(kStatusTagKey);
+  return descriptor;
+}
+
+const stats::ViewDescriptor& ServerRequestBytesMinute() {
+  const static stats::ViewDescriptor descriptor =
+      MinuteDescriptor()
+          .set_name("grpc.io/server/request_bytes/minute")
+          .set_measure(kRpcServerRequestBytesMeasureName)
+          .set_aggregation(BytesDistributionAggregation())
+          .add_column(kMethodTagKey);
+  return descriptor;
+}
+
+const stats::ViewDescriptor& ServerResponseBytesMinute() {
+  const static stats::ViewDescriptor descriptor =
+      MinuteDescriptor()
+          .set_name("grpc.io/server/response_bytes/minute")
+          .set_measure(kRpcServerResponseBytesMeasureName)
+          .set_aggregation(BytesDistributionAggregation())
+          .add_column(kMethodTagKey);
+  return descriptor;
+}
+
+const stats::ViewDescriptor& ServerServerElapsedTimeMinute() {
+  const static stats::ViewDescriptor descriptor =
+      MinuteDescriptor()
+          .set_name("grpc.io/server/server_elapsed_time/minute")
+          .set_measure(kRpcServerServerElapsedTimeMeasureName)
+          .set_aggregation(MillisDistributionAggregation())
+          .add_column(kMethodTagKey);
+  return descriptor;
+}
+
+const stats::ViewDescriptor& ServerStartedCountMinute() {
+  const static stats::ViewDescriptor descriptor =
+      MinuteDescriptor()
+          .set_name("grpc.io/server/started_count/minute")
+          .set_measure(kRpcServerStartedCountMeasureName)
+          .set_aggregation(stats::Aggregation::Sum())
+          .add_column(kMethodTagKey);
+  return descriptor;
+}
+
+const stats::ViewDescriptor& ServerFinishedCountMinute() {
+  const static stats::ViewDescriptor descriptor =
+      MinuteDescriptor()
+          .set_name("grpc.io/server/finished_count/minute")
+          .set_measure(kRpcServerFinishedCountMeasureName)
+          .set_aggregation(stats::Aggregation::Sum())
+          .add_column(kMethodTagKey);
+  return descriptor;
+}
+
+const stats::ViewDescriptor& ServerRequestCountMinute() {
+  const static stats::ViewDescriptor descriptor =
+      MinuteDescriptor()
+          .set_name("grpc.io/server/request_count/minute")
+          .set_measure(kRpcServerRequestCountMeasureName)
+          .set_aggregation(CountDistributionAggregation())
+          .add_column(kMethodTagKey);
+  return descriptor;
+}
+
+const stats::ViewDescriptor& ServerResponseCountMinute() {
+  const static stats::ViewDescriptor descriptor =
+      MinuteDescriptor()
+          .set_name("grpc.io/server/response_count/minute")
+          .set_measure(kRpcServerResponseCountMeasureName)
+          .set_aggregation(CountDistributionAggregation())
+          .add_column(kMethodTagKey);
+  return descriptor;
+}
+
+// client hour
+const stats::ViewDescriptor& ClientErrorCountHour() {
+  const static stats::ViewDescriptor descriptor =
+      HourDescriptor()
+          .set_name("grpc.io/client/error_count/hour")
+          .set_measure(kRpcClientErrorCountMeasureName)
+          .set_aggregation(stats::Aggregation::Sum())
+          .add_column(kMethodTagKey)
+          .add_column(kStatusTagKey);
+  return descriptor;
+}
+
+const stats::ViewDescriptor& ClientRequestBytesHour() {
+  const static stats::ViewDescriptor descriptor =
+      HourDescriptor()
+          .set_name("grpc.io/client/request_bytes/hour")
+          .set_measure(kRpcClientRequestBytesMeasureName)
+          .set_aggregation(BytesDistributionAggregation())
+          .add_column(kMethodTagKey);
+  return descriptor;
+}
+
+const stats::ViewDescriptor& ClientResponseBytesHour() {
+  const static stats::ViewDescriptor descriptor =
+      HourDescriptor()
+          .set_name("grpc.io/client/response_bytes/hour")
+          .set_measure(kRpcClientResponseBytesMeasureName)
+          .set_aggregation(BytesDistributionAggregation())
+          .add_column(kMethodTagKey);
+  return descriptor;
+}
+
+const stats::ViewDescriptor& ClientRoundtripLatencyHour() {
+  const static stats::ViewDescriptor descriptor =
+      HourDescriptor()
+          .set_name("grpc.io/client/roundtrip_latency/hour")
+          .set_measure(kRpcClientRoundtripLatencyMeasureName)
+          .set_aggregation(MillisDistributionAggregation())
+          .add_column(kMethodTagKey);
+  return descriptor;
+}
+
+const stats::ViewDescriptor& ClientServerElapsedTimeHour() {
+  const static stats::ViewDescriptor descriptor =
+      HourDescriptor()
+          .set_name("grpc.io/client/server_elapsed_time/hour")
+          .set_measure(kRpcClientServerElapsedTimeMeasureName)
+          .set_aggregation(MillisDistributionAggregation())
+          .add_column(kMethodTagKey);
+  return descriptor;
+}
+
+const stats::ViewDescriptor& ClientStartedCountHour() {
+  const static stats::ViewDescriptor descriptor =
+      HourDescriptor()
+          .set_name("grpc.io/client/started_count/hour")
+          .set_measure(kRpcClientStartedCountMeasureName)
+          .set_aggregation(stats::Aggregation::Sum())
+          .add_column(kMethodTagKey);
+  return descriptor;
+}
+
+const stats::ViewDescriptor& ClientFinishedCountHour() {
+  const static stats::ViewDescriptor descriptor =
+      HourDescriptor()
+          .set_name("grpc.io/client/finished_count/hour")
+          .set_measure(kRpcClientFinishedCountMeasureName)
+          .set_aggregation(stats::Aggregation::Sum())
+          .add_column(kMethodTagKey);
+  return descriptor;
+}
+
+const stats::ViewDescriptor& ClientRequestCountHour() {
+  const static stats::ViewDescriptor descriptor =
+      HourDescriptor()
+          .set_name("grpc.io/client/request_count/hour")
+          .set_measure(kRpcClientRequestCountMeasureName)
+          .set_aggregation(CountDistributionAggregation())
+          .add_column(kMethodTagKey);
+  return descriptor;
+}
+
+const stats::ViewDescriptor& ClientResponseCountHour() {
+  const static stats::ViewDescriptor descriptor =
+      HourDescriptor()
+          .set_name("grpc.io/client/response_count/hour")
+          .set_measure(kRpcClientResponseCountMeasureName)
+          .set_aggregation(CountDistributionAggregation())
+          .add_column(kMethodTagKey);
+  return descriptor;
+}
+
+// server hour
+const stats::ViewDescriptor& ServerErrorCountHour() {
+  const static stats::ViewDescriptor descriptor =
+      HourDescriptor()
+          .set_name("grpc.io/server/error_count/hour")
+          .set_measure(kRpcServerErrorCountMeasureName)
+          .set_aggregation(stats::Aggregation::Sum())
+          .add_column(kMethodTagKey)
+          .add_column(kStatusTagKey);
+  return descriptor;
+}
+
+const stats::ViewDescriptor& ServerRequestBytesHour() {
+  const static stats::ViewDescriptor descriptor =
+      HourDescriptor()
+          .set_name("grpc.io/server/request_bytes/hour")
+          .set_measure(kRpcServerRequestBytesMeasureName)
+          .set_aggregation(BytesDistributionAggregation())
+          .add_column(kMethodTagKey);
+  return descriptor;
+}
+
+const stats::ViewDescriptor& ServerResponseBytesHour() {
+  const static stats::ViewDescriptor descriptor =
+      HourDescriptor()
+          .set_name("grpc.io/server/response_bytes/hour")
+          .set_measure(kRpcServerResponseBytesMeasureName)
+          .set_aggregation(BytesDistributionAggregation())
+          .add_column(kMethodTagKey);
+  return descriptor;
+}
+
+const stats::ViewDescriptor& ServerServerElapsedTimeHour() {
+  const static stats::ViewDescriptor descriptor =
+      HourDescriptor()
+          .set_name("grpc.io/server/server_elapsed_time/hour")
+          .set_measure(kRpcServerServerElapsedTimeMeasureName)
+          .set_aggregation(MillisDistributionAggregation())
+          .add_column(kMethodTagKey);
+  return descriptor;
+}
+
+const stats::ViewDescriptor& ServerStartedCountHour() {
+  const static stats::ViewDescriptor descriptor =
+      HourDescriptor()
+          .set_name("grpc.io/server/started_count/hour")
+          .set_measure(kRpcServerStartedCountMeasureName)
+          .set_aggregation(stats::Aggregation::Sum())
+          .add_column(kMethodTagKey);
+  return descriptor;
+}
+
+const stats::ViewDescriptor& ServerFinishedCountHour() {
+  const static stats::ViewDescriptor descriptor =
+      HourDescriptor()
+          .set_name("grpc.io/server/finished_count/hour")
+          .set_measure(kRpcServerFinishedCountMeasureName)
+          .set_aggregation(stats::Aggregation::Sum())
+          .add_column(kMethodTagKey);
+  return descriptor;
+}
+
+const stats::ViewDescriptor& ServerRequestCountHour() {
+  const static stats::ViewDescriptor descriptor =
+      HourDescriptor()
+          .set_name("grpc.io/server/request_count/hour")
+          .set_measure(kRpcServerRequestCountMeasureName)
+          .set_aggregation(CountDistributionAggregation())
+          .add_column(kMethodTagKey);
+  return descriptor;
+}
+
+const stats::ViewDescriptor& ServerResponseCountHour() {
+  const static stats::ViewDescriptor descriptor =
+      HourDescriptor()
+          .set_name("grpc.io/server/response_count/hour")
+          .set_measure(kRpcServerResponseCountMeasureName)
+          .set_aggregation(CountDistributionAggregation())
+          .add_column(kMethodTagKey);
+  return descriptor;
+}
+
+}  // namespace opencensus

--- a/opencensus/stats/BUILD
+++ b/opencensus/stats/BUILD
@@ -24,6 +24,7 @@ package(default_visibility = ["//visibility:private"])
 cc_library(
     name = "stats",
     hdrs = [
+        "internal/aggregation_window.h",
         "internal/set_aggregation_window.h",
         "stats.h",
     ],


### PR DESCRIPTION
Uses RegisterForExport() from #61.