### PR TITLE
Reenable the stats_plugin_end2end_test on ci.

### DIFF
--- a/opencensus/plugins/grpc/BUILD
+++ b/opencensus/plugins/grpc/BUILD
@@ -65,13 +65,13 @@ cc_test(
     linkopts = [
         "-pthread",
     ],
-    tags = ["noci"],  # TODO: determine why this times out on Travis and reenable.
     deps = [
         ":grpc_plugin",
         "//opencensus/plugins/grpc/internal/testing:echo_proto",
         "//opencensus/stats",
         "@com_github_grpc_grpc//:grpc++",
         "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/time",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/opencensus/plugins/grpc/internal/stats_plugin_end2end_test.cc
+++ b/opencensus/plugins/grpc/internal/stats_plugin_end2end_test.cc
@@ -54,6 +54,7 @@ class StatsPluginEnd2EndTest : public ::testing::Test {
     // interface.
     ::grpc::ServerBuilder builder;
     int port;
+    // Use IPv4 here because it's less flaky than IPv6 ("[::]:0") on Travis.
     builder.AddListeningPort("0.0.0.0:0", ::grpc::InsecureServerCredentials(),
                              &port);
     builder.RegisterService(&service_);


### PR DESCRIPTION
Two changes:
- Switch to IPv4--for some reason this fixes the consistent timeouts, despite our Travis configuration nominally supporting IPv6 loopback.
- Add some short sleeps to give the server a chance to update stats before verifying.