### PR TITLE
Change the stats exporter interface to batch all views together.

### DIFF
--- a/opencensus/exporters/stats/stdout/internal/stdout_exporter.cc
+++ b/opencensus/exporters/stats/stdout/internal/stdout_exporter.cc
@@ -50,8 +50,9 @@ std::string DataToString(const opencensus::stats::Distribution& data) {
 class StdoutExporter::Handler
     : public opencensus::stats::StatsExporter::Handler {
  public:
-  void ExportViewData(const opencensus::stats::ViewDescriptor& descriptor,
-                      const opencensus::stats::ViewData& data) override;
+  void ExportViewData(
+      const std::vector<std::pair<opencensus::stats::ViewDescriptor,
+                                  opencensus::stats::ViewData>>& data) override;
 
  private:
   // Implements ExportViewData for supported data types.
@@ -69,21 +70,24 @@ void StdoutExporter::Register() {
 }
 
 void StdoutExporter::Handler::ExportViewData(
-    const opencensus::stats::ViewDescriptor& descriptor,
-    const opencensus::stats::ViewData& data) {
-  switch (data.type()) {
-    case opencensus::stats::ViewData::Type::kDouble:
-      ExportViewDataImpl(descriptor, data.start_time(), data.end_time(),
-                         data.double_data());
-      break;
-    case opencensus::stats::ViewData::Type::kInt64:
-      ExportViewDataImpl(descriptor, data.start_time(), data.end_time(),
-                         data.int_data());
-      break;
-    case opencensus::stats::ViewData::Type::kDistribution:
-      ExportViewDataImpl(descriptor, data.start_time(), data.end_time(),
-                         data.distribution_data());
-      break;
+    const std::vector<std::pair<opencensus::stats::ViewDescriptor,
+                                opencensus::stats::ViewData>>& data) {
+  for (const auto& datum : data) {
+    const auto& view_data = datum.second;
+    switch (view_data.type()) {
+      case opencensus::stats::ViewData::Type::kDouble:
+        ExportViewDataImpl(datum.first, view_data.start_time(),
+                           view_data.end_time(), view_data.double_data());
+        break;
+      case opencensus::stats::ViewData::Type::kInt64:
+        ExportViewDataImpl(datum.first, view_data.start_time(),
+                           view_data.end_time(), view_data.int_data());
+        break;
+      case opencensus::stats::ViewData::Type::kDistribution:
+        ExportViewDataImpl(datum.first, view_data.start_time(),
+                           view_data.end_time(), view_data.distribution_data());
+        break;
+    }
   }
 }
 

--- a/opencensus/stats/examples/exporter_example.cc
+++ b/opencensus/stats/examples/exporter_example.cc
@@ -42,24 +42,30 @@ class ExampleExporter : public opencensus::stats::StatsExporter::Handler {
         absl::make_unique<ExampleExporter>());
   }
 
-  void ExportViewData(const opencensus::stats::ViewDescriptor& descriptor,
-                      const opencensus::stats::ViewData& data) override {
-    if (data.type() != opencensus::stats::ViewData::Type::kDouble) {
-      // This example only supports double data (i.e. Sum() aggregation).
-      return;
-    }
-    std::string output;
-    absl::StrAppend(&output, "\nData for view \"", descriptor.name(),
-                    "\" from ", absl::FormatTime(data.start_time()), " to ",
-                    absl::FormatTime(data.end_time()), ":\n");
-    for (const auto& row : data.double_data()) {
-      for (int i = 0; i < descriptor.columns().size(); ++i) {
-        absl::StrAppend(&output, descriptor.columns()[i], ":", row.first[i],
-                        ", ");
+  void ExportViewData(
+      const std::vector<std::pair<opencensus::stats::ViewDescriptor,
+                                  opencensus::stats::ViewData>>& data)
+      override {
+    for (const auto& datum : data) {
+      const auto& descriptor = datum.first;
+      const auto& view_data = datum.second;
+      if (view_data.type() != opencensus::stats::ViewData::Type::kDouble) {
+        // This example only supports double data (i.e. Sum() aggregation).
+        return;
       }
-      absl::StrAppend(&output, row.second, "\n");
+      std::string output;
+      absl::StrAppend(&output, "\nData for view \"", descriptor.name(),
+                      "\" from ", absl::FormatTime(view_data.start_time()),
+                      " to ", absl::FormatTime(view_data.end_time()), ":\n");
+      for (const auto& row : view_data.double_data()) {
+        for (int i = 0; i < descriptor.columns().size(); ++i) {
+          absl::StrAppend(&output, descriptor.columns()[i], ":", row.first[i],
+                          ", ");
+        }
+        absl::StrAppend(&output, row.second, "\n");
+      }
+      std::cout << output;
     }
-    std::cout << output;
   }
 };
 

--- a/opencensus/stats/internal/stats_exporter_impl.h
+++ b/opencensus/stats/internal/stats_exporter_impl.h
@@ -49,9 +49,6 @@ class StatsExporterImpl {
  private:
   StatsExporterImpl() {}
 
-  void SendToHandlers(const ViewDescriptor& descriptor, const ViewData& data)
-      SHARED_LOCKS_REQUIRED(mu_);
-
   void StartExportThread() EXCLUSIVE_LOCKS_REQUIRED(mu_);
 
   // Loops forever, calling Export() every export_interval_.

--- a/opencensus/stats/stats_exporter.h
+++ b/opencensus/stats/stats_exporter.h
@@ -45,8 +45,8 @@ class StatsExporter final {
   class Handler {
    public:
     virtual ~Handler() = default;
-    virtual void ExportViewData(const ViewDescriptor& descriptor,
-                                const ViewData& data) = 0;
+    virtual void ExportViewData(
+        const std::vector<std::pair<ViewDescriptor, ViewData>>& data) = 0;
   };
 
   // This should only be called by push exporters' Register() methods.

--- a/opencensus/stats/view_data.h
+++ b/opencensus/stats/view_data.h
@@ -70,7 +70,6 @@ class ViewData {
   absl::Time end_time() const;
 
   ViewData(const ViewData& other);
-  // ViewData& operator=(const ViewData& other);
 
  private:
   friend class View;  // Allowed to call the private constructor.

--- a/opencensus/stats/view_data.h
+++ b/opencensus/stats/view_data.h
@@ -70,6 +70,7 @@ class ViewData {
   absl::Time end_time() const;
 
   ViewData(const ViewData& other);
+  // ViewData& operator=(const ViewData& other);
 
  private:
   friend class View;  // Allowed to call the private constructor.


### PR DESCRIPTION
This allows the Stackdriver exporter to batch TimeSeries from different views into the same RPCs.

stackdriver_e2e_test run manually.