### PR TITLE
Remove record_events from public API for now.

### DIFF
--- a/opencensus/trace/examples/span_example.cc
+++ b/opencensus/trace/examples/span_example.cc
@@ -51,13 +51,6 @@ TEST(SpanExample, AlwaysSample) {
   span.End();
 }
 
-TEST(SpanExample, RecordEvents) {
-  auto span = ::opencensus::trace::Span::StartSpan(
-      "MyRootSpan", /*parent=*/nullptr,
-      {/*sampler=*/nullptr, /*record_events=*/true});
-  span.End();
-}
-
 void PretendCallback(::opencensus::trace::Span&& s) {
   s.AddAnnotation("Performing work.");
   s.End();

--- a/opencensus/trace/internal/local_span_store_test.cc
+++ b/opencensus/trace/internal/local_span_store_test.cc
@@ -45,8 +45,8 @@ namespace {
 
 TEST(LocalSpanStoreTest, GetSummary) {
   exporter::LocalSpanStoreImplTestPeer::ClearForTesting();
-  auto span = Span::StartSpan("SpanName", /*parent=*/nullptr,
-                              {nullptr, /*record_events=*/true});
+  static AlwaysSampler sampler;
+  auto span = Span::StartSpan("SpanName", /*parent=*/nullptr, {&sampler});
   span.AddAnnotation("Annotation");
   SpanTestPeer::End(absl::Microseconds(15), &span);
 

--- a/opencensus/trace/internal/span.cc
+++ b/opencensus/trace/internal/span.cc
@@ -93,8 +93,8 @@ class SpanGenerator {
     }
     SpanContext context(trace_id, span_id, trace_options);
     SpanImpl* impl = nullptr;
-    if (trace_options.IsSampled() || options.record_events) {
-      // Only Spans that are recording are backed by a SpanImpl.
+    if (trace_options.IsSampled()) {
+      // Only Spans that are sampled are backed by a SpanImpl.
       impl =
           new SpanImpl(context, TraceConfigImpl::Get()->current_trace_params(),
                        name, parent_span_id, has_remote_parent);

--- a/opencensus/trace/span.h
+++ b/opencensus/trace/span.h
@@ -50,13 +50,9 @@ using AttributesRef =
 
 // Options for Starting a Span.
 struct StartSpanOptions {
-  StartSpanOptions(
-      Sampler* sampler = nullptr,  // Default Sampler.
-      bool record_events = false,  // Only record events if the Span is sampled.
-      const std::vector<Span*>& parent_links = {})
-      : sampler(sampler),
-        record_events(record_events),
-        parent_links(parent_links) {}
+  StartSpanOptions(Sampler* sampler = nullptr,  // Default Sampler.
+                   const std::vector<Span*>& parent_links = {})
+      : sampler(sampler), parent_links(parent_links) {}
 
   // The Sampler to use. It must remain valid for the duration of the
   // StartSpan() call. If nullptr, use the default Sampler from TraceConfig.
@@ -64,11 +60,6 @@ struct StartSpanOptions {
   // A Span that's sampled will be exported (see exporter/span_exporter.h).
   // All sampled Spans record events.
   const Sampler* sampler;
-
-  // This option can be used to request recording of events for non-sampled
-  // Spans. Spans that record events show up in the RunningSpanStore and
-  // LocalSpanStore in the running process.
-  const bool record_events;
 
   // Pointers to Spans in *other Traces* that are parents of this Span. They
   // must remain valid for the duration of the StartSpan() call.


### PR DESCRIPTION
This is in preparation for changing how SpanStores work.