### PR TITLE
Update the prometheus_cpp workspace name.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -82,13 +82,14 @@ cc_library(
 )
 
 http_archive(
-    name = "prometheus_cpp",
+    name = "com_github_jupp0r_prometheus_cpp",
     strip_prefix = "prometheus-cpp-master",
     urls = ["https://github.com/jupp0r/prometheus-cpp/archive/master.zip"],
 )
 
-load("@prometheus_cpp//:repositories.bzl", "load_prometheus_client_model",
-					   "load_civetweb")
+load("@com_github_jupp0r_prometheus_cpp//:repositories.bzl",
+     "load_prometheus_client_model",
+     "load_civetweb")
 
 # Load dependencies individually since we load some of them above.
 load_prometheus_client_model()

--- a/examples/grpc/BUILD
+++ b/examples/grpc/BUILD
@@ -74,7 +74,7 @@ cc_binary(
         "//opencensus/plugins/grpc:grpc_plugin",
         "//opencensus/trace",
         "@com_github_grpc_grpc//:grpc++",
+        "@com_github_jupp0r_prometheus_cpp//:prometheus_cpp",
         "@com_google_absl//absl/strings",
-        "@prometheus_cpp",
     ],
 )

--- a/opencensus/exporters/stats/prometheus/BUILD
+++ b/opencensus/exporters/stats/prometheus/BUILD
@@ -27,8 +27,8 @@ cc_library(
     deps = [
         ":prometheus_utils",
         "//opencensus/stats",
+        "@com_github_jupp0r_prometheus_cpp//:prometheus_cpp",
         "@prometheus_client_model",
-        "@prometheus_cpp",
     ],
 )
 
@@ -72,7 +72,7 @@ cc_binary(
     deps = [
         ":prometheus_exporter",
         "//opencensus/stats",
+        "@com_github_jupp0r_prometheus_cpp//:prometheus_cpp",
         "@com_google_absl//absl/time",
-        "@prometheus_cpp",
     ],
 )


### PR DESCRIPTION
Changed upstream in https://github.com/jupp0r/prometheus-cpp/pull/97.