### PR TITLE
In debug builds, assert() that End() isn't called more than once.

### DIFF
--- a/opencensus/trace/internal/span.cc
+++ b/opencensus/trace/internal/span.cc
@@ -201,7 +201,12 @@ void Span::SetStatus(StatusCode canonical_code, absl::string_view message) {
 }
 
 void Span::End() {
-  if (IsRecording() && !span_impl_->HasEnded()) {
+  if (IsRecording()) {
+    if (span_impl_->HasEnded()) {
+      assert(false && "Invalid attempt to End() the same Span more than once.");
+      // In non-debug builds, ignore the second End().
+      return;
+    }
     span_impl_->End();
     exporter::RunningSpanStoreImpl::Get()->RemoveSpan(span_impl_);
     exporter::LocalSpanStoreImpl::Get()->AddSpan(span_impl_);


### PR DESCRIPTION
Followup to: https://github.com/census-instrumentation/opencensus-cpp/pull/70