### PR TITLE
Add a TagSet class providing equality and hashing for key/value maps.

### DIFF
--- a/opencensus/stats/BUILD
+++ b/opencensus/stats/BUILD
@@ -65,6 +65,7 @@ cc_library(
         "internal/set_aggregation_window.cc",
         "internal/stats_exporter.cc",
         "internal/stats_manager.cc",
+        "internal/tag_set.cc",
         "internal/view.cc",
         "internal/view_data.cc",
         "internal/view_data_impl.cc",
@@ -84,6 +85,7 @@ cc_library(
         "measure_descriptor.h",
         "measure_registry.h",
         "stats_exporter.h",
+        "tag_set.h",
         "view.h",
         "view_data.h",
         "view_descriptor.h",
@@ -181,6 +183,17 @@ cc_test(
         ":core",
         ":recording",
         "@com_google_absl//absl/types:optional",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "tag_set_test",
+    size = "small",
+    srcs = ["internal/tag_set_test.cc"],
+    copts = TEST_COPTS,
+    deps = [
+        ":core",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/opencensus/stats/internal/tag_set.cc
+++ b/opencensus/stats/internal/tag_set.cc
@@ -1,0 +1,70 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "opencensus/stats/tag_set.h"
+
+#include <functional>
+#include <initializer_list>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "absl/strings/string_view.h"
+
+namespace opencensus {
+namespace stats {
+
+TagSet::TagSet(
+    std::initializer_list<std::pair<absl::string_view, absl::string_view>>
+        tags) {
+  tags_.reserve(tags.size());
+  for (const auto& tag : tags) {
+    tags_.emplace_back(std::string(tag.first), std::string(tag.second));
+  }
+  Initialize();
+}
+
+TagSet::TagSet(std::vector<std::pair<std::string, std::string>> tags)
+    : tags_(std::move(tags)) {
+  Initialize();
+}
+
+void TagSet::Initialize() {
+  std::sort(tags_.begin(), tags_.end());
+
+  std::hash<std::string> hasher;
+  hash_ = 1;
+  for (const auto& tag : tags_) {
+    static const size_t kMul = static_cast<size_t>(0xdc3eb94af8ab4c93ULL);
+    hash_ *= kMul;
+    hash_ = ((hash_ << 19) |
+             (hash_ >> (std::numeric_limits<size_t>::digits - 19))) +
+            hasher(tag.first);
+    hash_ *= kMul;
+    hash_ = ((hash_ << 19) |
+             (hash_ >> (std::numeric_limits<size_t>::digits - 19))) +
+            hasher(tag.second);
+  }
+}
+
+std::size_t TagSet::Hash::operator()(const TagSet& tag_set) const {
+  return tag_set.hash_;
+}
+
+bool TagSet::operator==(const TagSet& other) const {
+  return tags_ == other.tags_;
+}
+
+}  // namespace stats
+}  // namespace opencensus

--- a/opencensus/stats/internal/tag_set_test.cc
+++ b/opencensus/stats/internal/tag_set_test.cc
@@ -1,0 +1,81 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "opencensus/stats/tag_set.h"
+
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+namespace opencensus {
+namespace stats {
+namespace {
+
+TEST(TagSetTest, ConstructorsEquivalent) {
+  const std::vector<std::pair<std::string, std::string>> tags({{"k", "v"}});
+  EXPECT_EQ(TagSet(tags), TagSet({{"k", "v"}}));
+}
+
+TEST(TagSetTest, TagsSorted) {
+  const std::vector<std::pair<std::string, std::string>> expected = {
+      {"B", "v"}, {"a", "v"}, {"b", "v"}};
+  const std::vector<std::pair<std::string, std::string>> tags(
+      {{"b", "v"}, {"a", "v"}, {"B", "v"}});
+  EXPECT_THAT(TagSet(tags).tags(), ::testing::ElementsAreArray(expected));
+  EXPECT_THAT(TagSet({{"B", "v"}, {"b", "v"}, {"a", "v"}}).tags(),
+              ::testing::ElementsAreArray(expected));
+}
+
+TEST(TagSetTest, EqualityDisregardsOrder) {
+  EXPECT_EQ(TagSet({{"k1", "v1"}, {"k2", "v2"}}),
+            TagSet({{"k2", "v2"}, {"k1", "v1"}}));
+}
+
+TEST(TagSetTest, EqualityRespectsMissingKeys) {
+  EXPECT_NE(TagSet({{"k1", "v1"}, {"k2", "v2"}}), TagSet({{"k1", "v1"}}));
+}
+
+TEST(TagSetTest, EqualityRespectsKeyValuePairings) {
+  EXPECT_NE(TagSet({{"k1", "v1"}, {"k2", "v2"}}),
+            TagSet({{"k1", "v2"}, {"k2", "v1"}}));
+}
+
+TEST(TagSetTest, HashDisregardsOrder) {
+  TagSet ts1({{"k1", "v1"}, {"k2", "v2"}});
+  TagSet ts2({{"k2", "v2"}, {"k1", "v1"}});
+  EXPECT_EQ(TagSet::Hash()(ts1), TagSet::Hash()(ts2));
+}
+
+TEST(TagSetTest, HashRespectsKeyValuePairings) {
+  TagSet ts1({{"k1", "v1"}, {"k2", "v2"}});
+  TagSet ts2({{"k1", "v2"}, {"k2", "v1"}});
+  EXPECT_NE(TagSet::Hash()(ts1), TagSet::Hash()(ts2));
+}
+
+TEST(TagSetTest, UnorderedMap) {
+  // Test that the operators and hash are compatible with std::unordered_map.
+  std::unordered_map<TagSet, int, TagSet::Hash> map;
+  TagSet ts = {{"key", "value"}};
+  map.emplace(ts, 1);
+  EXPECT_NE(map.end(), map.find(ts));
+  EXPECT_EQ(1, map.erase(ts));
+}
+
+}  // namespace
+}  // namespace stats
+}  // namespace opencensus

--- a/opencensus/stats/stats.h
+++ b/opencensus/stats/stats.h
@@ -24,6 +24,7 @@
 #include "opencensus/stats/measure_registry.h"    // IWYU pragma: export
 #include "opencensus/stats/recording.h"           // IWYU pragma: export
 #include "opencensus/stats/stats_exporter.h"      // IWYU pragma: export
+#include "opencensus/stats/tag_set.h"             // IWYU pragma: export
 #include "opencensus/stats/view.h"                // IWYU pragma: export
 #include "opencensus/stats/view_data.h"           // IWYU pragma: export
 #include "opencensus/stats/view_descriptor.h"     // IWYU pragma: export

--- a/opencensus/stats/tag_set.h
+++ b/opencensus/stats/tag_set.h
@@ -1,0 +1,66 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef OPENCENSUS_STATS_TAG_SET_H_
+#define OPENCENSUS_STATS_TAG_SET_H_
+
+#include <initializer_list>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "absl/strings/string_view.h"
+
+namespace opencensus {
+namespace stats {
+
+// TagSet represents a set of key-value tags, and provides efficient equality
+// and hash operations. A TagSet is expensive to construct, and should be shared
+// between uses where possible.
+// TagSet is immutable.
+class TagSet final {
+ public:
+  // Both constructors are not explicit so that Record({}, {{"k", "v"}}) works.
+  // This constructor is needed because even though we copy to a vector
+  // internally because c++ cannot deduce the conversion needed.
+  TagSet(std::initializer_list<std::pair<absl::string_view, absl::string_view>>
+             tags);
+  // This constructor is needed so that callers can dynamically construct
+  // tagsets. It takes the argument by value to allow it to be moved.
+  TagSet(std::vector<std::pair<std::string, std::string>> tags);
+
+  // Accesses the tags sorted by key.
+  const std::vector<std::pair<std::string, std::string>>& tags() const {
+    return tags_;
+  }
+
+  struct Hash {
+    std::size_t operator()(const TagSet& tag_set) const;
+  };
+
+  bool operator==(const TagSet& other) const;
+  bool operator!=(const TagSet& other) const { return !(*this == other); }
+
+ private:
+  void Initialize();
+
+  std::size_t hash_;
+  // TODO: add an option to store string_views to avoid copies.
+  std::vector<std::pair<std::string, std::string>> tags_;
+};
+
+}  // namespace stats
+}  // namespace opencensus
+
+#endif  // OPENCENSUS_STATS_TAG_SET_H_


### PR DESCRIPTION
This is needed for the DeltaProducer--the ViewData maps include only the tag values in ViewDescriptor order, but since the DeltaProducer aggregates before view aggregation we need to keep the entire mapping.