### PR TITLE
Move measure registration to Measure from MeasureRegistry.

### DIFF
--- a/examples/helloworld/helloworld.cc
+++ b/examples/helloworld/helloworld.cc
@@ -37,10 +37,10 @@ ABSL_CONST_INIT const absl::string_view kVideoSizeMeasureName =
 // The resource owner defines and registers a measure. A function exposing a
 // function-local static is the recommended style, ensuring that the measure is
 // only registered once.
-opencensus::stats::MeasureInt VideoSizeMeasure() {
-  static const opencensus::stats::MeasureInt video_size =
-      opencensus::stats::MeasureRegistry::RegisterInt(
-          kVideoSizeMeasureName, "By", "size of processed videos");
+opencensus::stats::MeasureInt64 VideoSizeMeasure() {
+  static const opencensus::stats::MeasureInt64 video_size =
+      opencensus::stats::MeasureInt64::Register(
+          kVideoSizeMeasureName, "size of processed videos", "By");
   return video_size;
 }
 

--- a/opencensus/exporters/stats/prometheus/internal/prometheus_test_server.cc
+++ b/opencensus/exporters/stats/prometheus/internal/prometheus_test_server.cc
@@ -34,8 +34,8 @@ int main(int argc, char** argv) {
   // Create a view and register it with the exporter.
   const std::string foo_usage_measure_name = "example.com/Foo/FooUsage";
   const opencensus::stats::MeasureDouble foo_usage =
-      opencensus::stats::MeasureRegistry::RegisterDouble(
-          foo_usage_measure_name, "foos", "Usage of foos.");
+      opencensus::stats::MeasureDouble::Register(foo_usage_measure_name,
+                                                 "Usage of foos.", "foos");
   const auto view_descriptor =
       opencensus::stats::ViewDescriptor()
           .set_name("example.com/Bar/FooUsage-sum-cumulative-key1-key2")

--- a/opencensus/exporters/stats/prometheus/internal/prometheus_utils_test.cc
+++ b/opencensus/exporters/stats/prometheus/internal/prometheus_utils_test.cc
@@ -50,8 +50,8 @@ void CompareMetricFamilies(const io::prometheus::client::MetricFamily& actual,
 }
 
 TEST(SetMetricFamilyTest, CountDouble) {
-  const auto measure = opencensus::stats::MeasureRegistry::RegisterDouble(
-      "measure_count_double", "units", "");
+  const auto measure = opencensus::stats::MeasureDouble::Register(
+      "measure_count_double", "", "units");
   const std::string task = "test_task";
   const std::string view_name = "test_descriptor";
   const auto tag_key_1 = opencensus::stats::TagKey::Register("foo");
@@ -86,8 +86,8 @@ TEST(SetMetricFamilyTest, CountDouble) {
 }
 
 TEST(SetMetricFamilyTest, SumDouble) {
-  const auto measure = opencensus::stats::MeasureRegistry::RegisterDouble(
-      "measure_sum_double", "units", "");
+  const auto measure = opencensus::stats::MeasureDouble::Register(
+      "measure_sum_double", "", "units");
   const std::string task = "test_task";
   const std::string view_name = "test_descriptor";
   const auto tag_key_1 = opencensus::stats::TagKey::Register("foo");
@@ -122,8 +122,8 @@ TEST(SetMetricFamilyTest, SumDouble) {
 }
 
 TEST(SetMetricFamilyTest, SumInt) {
-  const auto measure = opencensus::stats::MeasureRegistry::RegisterInt(
-      "measure_sum_int", "units", "");
+  const auto measure =
+      opencensus::stats::MeasureInt64::Register("measure_sum_int", "", "units");
   const std::string task = "test_task";
   const std::string view_name = "test_descriptor";
   const auto tag_key_1 = opencensus::stats::TagKey::Register("foo");
@@ -158,8 +158,8 @@ TEST(SetMetricFamilyTest, SumInt) {
 }
 
 TEST(StackdriverUtilsTest, MakeTimeSeriesDistributionDouble) {
-  const auto measure = opencensus::stats::MeasureRegistry::RegisterDouble(
-      "measure_distribution_double", "units", "");
+  const auto measure = opencensus::stats::MeasureDouble::Register(
+      "measure_distribution_double", "", "units");
   const std::string view_name = "test_descriptor";
   const auto tag_key_1 = opencensus::stats::TagKey::Register("foo");
   const auto tag_key_2 = opencensus::stats::TagKey::Register("bar");

--- a/opencensus/exporters/stats/stackdriver/README.md
+++ b/opencensus/exporters/stats/stackdriver/README.md
@@ -89,6 +89,6 @@ values.
 
 The Stackdriver data type depends on the
 view's measure type and aggregation--count aggregation to `INT64`, sum
-aggregation to `INT64` for `MeasureInt` and `DOUBLE` for `MeasureDouble`, and
+aggregation to `INT64` for `MeasureInt64` and `DOUBLE` for `MeasureDouble`, and
 distribution aggregation to `DISTRIBUTION`. Exported distributions omit the
 range as it is not supported by Stackdriver.

--- a/opencensus/exporters/stats/stackdriver/internal/stackdriver_e2e_test.cc
+++ b/opencensus/exporters/stats/stackdriver/internal/stackdriver_e2e_test.cc
@@ -51,8 +51,8 @@ constexpr char kGoogleStackdriverStatsAddress[] = "monitoring.googleapis.com";
 constexpr char kTestMeasureName[] = "opencensus.io/TestMeasure";
 opencensus::stats::MeasureDouble TestMeasure() {
   static const opencensus::stats::MeasureDouble foo_usage =
-      opencensus::stats::MeasureRegistry::RegisterDouble(
-          kTestMeasureName, "1{test units}", "Test measure.");
+      opencensus::stats::MeasureDouble::Register(
+          kTestMeasureName, "Test measure.", "1{test units}");
   return foo_usage;
 }
 

--- a/opencensus/exporters/stats/stackdriver/internal/stackdriver_utils_test.cc
+++ b/opencensus/exporters/stats/stackdriver/internal/stackdriver_utils_test.cc
@@ -85,8 +85,8 @@ TEST(StackdriverUtilsTest, SetMetricDescriptorMetricKind) {
 TEST(StackdriverUtilsTest, SetMetricDescriptorValueType) {
   auto view_descriptor = opencensus::stats::ViewDescriptor();
   google::api::MetricDescriptor metric_descriptor;
-  opencensus::stats::MeasureRegistry::RegisterDouble("double_measure", "", "");
-  opencensus::stats::MeasureRegistry::RegisterInt("int_measure", "", "");
+  opencensus::stats::MeasureDouble::Register("double_measure", "", "");
+  opencensus::stats::MeasureInt64::Register("int_measure", "", "");
 
   // Sum depends on measure type.
   view_descriptor.set_aggregation(opencensus::stats::Aggregation::Sum());
@@ -124,7 +124,7 @@ TEST(StackdriverUtilsTest, SetMetricDescriptorValueType) {
 
 TEST(StackdriverUtilsTest, SetMetricDescriptorUnits) {
   const std::string units = "test_units";
-  opencensus::stats::MeasureRegistry::RegisterDouble("measure", units, "");
+  opencensus::stats::MeasureDouble::Register("measure", "", units);
   const auto view_descriptor =
       opencensus::stats::ViewDescriptor().set_measure("measure");
   google::api::MetricDescriptor metric_descriptor;
@@ -144,8 +144,8 @@ TEST(StackdriverUtilsTest, SetMetricDescriptorDescription) {
 }
 
 TEST(StackdriverUtilsTest, MakeTimeSeriesSumDouble) {
-  const auto measure = opencensus::stats::MeasureRegistry::RegisterDouble(
-      "measure_sum_double", "", "");
+  const auto measure =
+      opencensus::stats::MeasureDouble::Register("measure_sum_double", "", "");
   const std::string task = "test_task";
   const std::string view_name = "test_view";
   const auto tag_key_1 = opencensus::stats::TagKey::Register("foo");
@@ -185,8 +185,8 @@ TEST(StackdriverUtilsTest, MakeTimeSeriesSumDouble) {
 }
 
 TEST(StackdriverUtilsTest, MakeTimeSeriesSumInt) {
-  const auto measure = opencensus::stats::MeasureRegistry::RegisterInt(
-      "measure_sum_int", "", "");
+  const auto measure =
+      opencensus::stats::MeasureInt64::Register("measure_sum_int", "", "");
   const std::string task = "test_task";
   const std::string view_name = "test_descriptor";
   const auto tag_key_1 = opencensus::stats::TagKey::Register("foo");
@@ -227,7 +227,7 @@ TEST(StackdriverUtilsTest, MakeTimeSeriesSumInt) {
 }
 
 TEST(StackdriverUtilsTest, MakeTimeSeriesCountDouble) {
-  const auto measure = opencensus::stats::MeasureRegistry::RegisterDouble(
+  const auto measure = opencensus::stats::MeasureDouble::Register(
       "measure_count_double", "", "");
   const std::string task = "test_task";
   const std::string view_name = "test_descriptor";
@@ -270,7 +270,7 @@ TEST(StackdriverUtilsTest, MakeTimeSeriesCountDouble) {
 }
 
 TEST(StackdriverUtilsTest, MakeTimeSeriesDistributionDouble) {
-  const auto measure = opencensus::stats::MeasureRegistry::RegisterDouble(
+  const auto measure = opencensus::stats::MeasureDouble::Register(
       "measure_distribution_double", "", "");
   const std::string task = "test_task";
   const std::string view_name = "test_view";

--- a/opencensus/plugins/grpc/internal/measures.cc
+++ b/opencensus/plugins/grpc/internal/measures.cc
@@ -33,117 +33,117 @@ constexpr char kCount[] = "1";
 }  // namespace
 
 // Client
-stats::MeasureInt RpcClientErrorCount() {
-  static stats::MeasureInt measure = stats::MeasureRegistry::RegisterInt(
-      kRpcClientErrorCountMeasureName, kCount, "RPC Errors");
+stats::MeasureInt64 RpcClientErrorCount() {
+  static stats::MeasureInt64 measure = stats::MeasureInt64::Register(
+      kRpcClientErrorCountMeasureName, "RPC Errors", kCount);
   return measure;
 }
 
 stats::MeasureDouble RpcClientRequestBytes() {
-  static stats::MeasureDouble measure = stats::MeasureRegistry::RegisterDouble(
-      kRpcClientRequestBytesMeasureName, kUnitBytes, "Request bytes");
+  static stats::MeasureDouble measure = stats::MeasureDouble::Register(
+      kRpcClientRequestBytesMeasureName, "Request bytes", kUnitBytes);
   return measure;
 }
 
 stats::MeasureDouble RpcClientResponseBytes() {
-  static stats::MeasureDouble measure = stats::MeasureRegistry::RegisterDouble(
-      kRpcClientResponseBytesMeasureName, kUnitBytes, "Response bytes");
+  static stats::MeasureDouble measure = stats::MeasureDouble::Register(
+      kRpcClientResponseBytesMeasureName, "Response bytes", kUnitBytes);
   return measure;
 }
 
 stats::MeasureDouble RpcClientRoundtripLatency() {
-  static stats::MeasureDouble measure = stats::MeasureRegistry::RegisterDouble(
-      kRpcClientRoundtripLatencyMeasureName, kUnitMilliseconds,
-      "RPC roundtrip latency msec");
+  static stats::MeasureDouble measure = stats::MeasureDouble::Register(
+      kRpcClientRoundtripLatencyMeasureName, "RPC roundtrip latency msec",
+      kUnitMilliseconds);
   return measure;
 }
 
 stats::MeasureDouble RpcClientServerElapsedTime() {
-  static stats::MeasureDouble measure = stats::MeasureRegistry::RegisterDouble(
-      kRpcClientServerElapsedTimeMeasureName, kUnitMilliseconds,
-      "Server elapsed time in msecs");
+  static stats::MeasureDouble measure = stats::MeasureDouble::Register(
+      kRpcClientServerElapsedTimeMeasureName, "Server elapsed time in msecs",
+      kUnitMilliseconds);
   return measure;
 }
 
-stats::MeasureInt RpcClientStartedCount() {
-  static stats::MeasureInt measure = stats::MeasureRegistry::RegisterInt(
-      kRpcClientStartedCountMeasureName, kCount,
-      "Number of client RPCs (streams) started");
+stats::MeasureInt64 RpcClientStartedCount() {
+  static stats::MeasureInt64 measure = stats::MeasureInt64::Register(
+      kRpcClientStartedCountMeasureName,
+      "Number of client RPCs (streams) started", kCount);
   return measure;
 }
 
-stats::MeasureInt RpcClientFinishedCount() {
-  static stats::MeasureInt measure = stats::MeasureRegistry::RegisterInt(
-      kRpcClientFinishedCountMeasureName, kCount,
-      "Number of client RPCs (streams) finished");
+stats::MeasureInt64 RpcClientFinishedCount() {
+  static stats::MeasureInt64 measure = stats::MeasureInt64::Register(
+      kRpcClientFinishedCountMeasureName,
+      "Number of client RPCs (streams) finished", kCount);
   return measure;
 }
 
-stats::MeasureInt RpcClientRequestCount() {
-  static stats::MeasureInt measure = stats::MeasureRegistry::RegisterInt(
-      kRpcClientRequestCountMeasureName, kCount,
-      "Number of client RPC request messages");
+stats::MeasureInt64 RpcClientRequestCount() {
+  static stats::MeasureInt64 measure = stats::MeasureInt64::Register(
+      kRpcClientRequestCountMeasureName,
+      "Number of client RPC request messages", kCount);
   return measure;
 }
 
-stats::MeasureInt RpcClientResponseCount() {
-  static stats::MeasureInt measure = stats::MeasureRegistry::RegisterInt(
-      kRpcClientResponseCountMeasureName, kCount,
-      "Number of client RPC response messages");
+stats::MeasureInt64 RpcClientResponseCount() {
+  static stats::MeasureInt64 measure = stats::MeasureInt64::Register(
+      kRpcClientResponseCountMeasureName,
+      "Number of client RPC response messages", kCount);
   return measure;
 }
 
 // Server
-stats::MeasureInt RpcServerErrorCount() {
-  static stats::MeasureInt measure = stats::MeasureRegistry::RegisterInt(
-      kRpcServerErrorCountMeasureName, kCount, "RPC Errors");
+stats::MeasureInt64 RpcServerErrorCount() {
+  static stats::MeasureInt64 measure = stats::MeasureInt64::Register(
+      kRpcServerErrorCountMeasureName, "RPC Errors", kCount);
   return measure;
 }
 
 stats::MeasureDouble RpcServerRequestBytes() {
-  static stats::MeasureDouble measure = stats::MeasureRegistry::RegisterDouble(
-      kRpcServerRequestBytesMeasureName, kUnitBytes, "Request bytes");
+  static stats::MeasureDouble measure = stats::MeasureDouble::Register(
+      kRpcServerRequestBytesMeasureName, "Request bytes", kUnitBytes);
   return measure;
 }
 
 stats::MeasureDouble RpcServerResponseBytes() {
-  static stats::MeasureDouble measure = stats::MeasureRegistry::RegisterDouble(
-      kRpcServerResponseBytesMeasureName, kUnitBytes, "Response bytes");
+  static stats::MeasureDouble measure = stats::MeasureDouble::Register(
+      kRpcServerResponseBytesMeasureName, "Response bytes", kUnitBytes);
   return measure;
 }
 
 stats::MeasureDouble RpcServerServerElapsedTime() {
-  static stats::MeasureDouble measure = stats::MeasureRegistry::RegisterDouble(
-      kRpcServerServerElapsedTimeMeasureName, kUnitMilliseconds,
-      "Server elapsed time in msecs");
+  static stats::MeasureDouble measure = stats::MeasureDouble::Register(
+      kRpcServerServerElapsedTimeMeasureName, "Server elapsed time in msecs",
+      kUnitMilliseconds);
   return measure;
 }
 
-stats::MeasureInt RpcServerStartedCount() {
-  static stats::MeasureInt measure = stats::MeasureRegistry::RegisterInt(
-      kRpcServerStartedCountMeasureName, kCount,
-      "Number of server RPCs (streams) started");
+stats::MeasureInt64 RpcServerStartedCount() {
+  static stats::MeasureInt64 measure = stats::MeasureInt64::Register(
+      kRpcServerStartedCountMeasureName,
+      "Number of server RPCs (streams) started", kCount);
   return measure;
 }
 
-stats::MeasureInt RpcServerFinishedCount() {
-  static stats::MeasureInt measure = stats::MeasureRegistry::RegisterInt(
-      kRpcServerFinishedCountMeasureName, kCount,
-      "Number of server RPCs (streams) finished");
+stats::MeasureInt64 RpcServerFinishedCount() {
+  static stats::MeasureInt64 measure = stats::MeasureInt64::Register(
+      kRpcServerFinishedCountMeasureName,
+      "Number of server RPCs (streams) finished", kCount);
   return measure;
 }
 
-stats::MeasureInt RpcServerRequestCount() {
-  static stats::MeasureInt measure = stats::MeasureRegistry::RegisterInt(
-      kRpcServerRequestCountMeasureName, kCount,
-      "Number of server RPC request messages");
+stats::MeasureInt64 RpcServerRequestCount() {
+  static stats::MeasureInt64 measure = stats::MeasureInt64::Register(
+      kRpcServerRequestCountMeasureName,
+      "Number of server RPC request messages", kCount);
   return measure;
 }
 
-stats::MeasureInt RpcServerResponseCount() {
-  static stats::MeasureInt measure = stats::MeasureRegistry::RegisterInt(
-      kRpcServerResponseCountMeasureName, kCount,
-      "Number of server RPC response messages");
+stats::MeasureInt64 RpcServerResponseCount() {
+  static stats::MeasureInt64 measure = stats::MeasureInt64::Register(
+      kRpcServerResponseCountMeasureName,
+      "Number of server RPC response messages", kCount);
   return measure;
 }
 

--- a/opencensus/plugins/grpc/internal/measures.h
+++ b/opencensus/plugins/grpc/internal/measures.h
@@ -20,24 +20,24 @@
 
 namespace opencensus {
 
-stats::MeasureInt RpcClientErrorCount();
+stats::MeasureInt64 RpcClientErrorCount();
 stats::MeasureDouble RpcClientRequestBytes();
 stats::MeasureDouble RpcClientResponseBytes();
 stats::MeasureDouble RpcClientRoundtripLatency();
 stats::MeasureDouble RpcClientServerElapsedTime();
-stats::MeasureInt RpcClientStartedCount();
-stats::MeasureInt RpcClientFinishedCount();
-stats::MeasureInt RpcClientRequestCount();
-stats::MeasureInt RpcClientResponseCount();
+stats::MeasureInt64 RpcClientStartedCount();
+stats::MeasureInt64 RpcClientFinishedCount();
+stats::MeasureInt64 RpcClientRequestCount();
+stats::MeasureInt64 RpcClientResponseCount();
 
-stats::MeasureInt RpcServerErrorCount();
+stats::MeasureInt64 RpcServerErrorCount();
 stats::MeasureDouble RpcServerRequestBytes();
 stats::MeasureDouble RpcServerResponseBytes();
 stats::MeasureDouble RpcServerServerElapsedTime();
-stats::MeasureInt RpcServerStartedCount();
-stats::MeasureInt RpcServerFinishedCount();
-stats::MeasureInt RpcServerRequestCount();
-stats::MeasureInt RpcServerResponseCount();
+stats::MeasureInt64 RpcServerStartedCount();
+stats::MeasureInt64 RpcServerFinishedCount();
+stats::MeasureInt64 RpcServerRequestCount();
+stats::MeasureInt64 RpcServerResponseCount();
 
 }  // namespace opencensus
 

--- a/opencensus/stats/examples/exporter_example.cc
+++ b/opencensus/stats/examples/exporter_example.cc
@@ -29,8 +29,8 @@ constexpr char kFooUsageMeasureName[] = "example.com/Foo/FooUsage";
 
 opencensus::stats::MeasureDouble FooUsage() {
   static const opencensus::stats::MeasureDouble foo_usage =
-      opencensus::stats::MeasureRegistry::RegisterDouble(
-          kFooUsageMeasureName, "foos", "Usage of foos.");
+      opencensus::stats::MeasureDouble::Register(kFooUsageMeasureName, "foos",
+                                                 "Usage of foos.");
   return foo_usage;
 }
 

--- a/opencensus/stats/examples/view_and_recording_example.cc
+++ b/opencensus/stats/examples/view_and_recording_example.cc
@@ -26,8 +26,8 @@ constexpr char kFooUsageMeasureName[] = "example.com/Foo/FooUsage";
 // only registered once.
 opencensus::stats::MeasureDouble FooUsage() {
   static const opencensus::stats::MeasureDouble foo_usage =
-      opencensus::stats::MeasureRegistry::RegisterDouble(
-          kFooUsageMeasureName, "foos", "Usage of foos.");
+      opencensus::stats::MeasureDouble::Register(kFooUsageMeasureName,
+                                                 "Usage of foos.", "foos");
   return foo_usage;
 }
 

--- a/opencensus/stats/internal/debug_string_test.cc
+++ b/opencensus/stats/internal/debug_string_test.cc
@@ -20,8 +20,8 @@
 #include "opencensus/stats/aggregation.h"
 #include "opencensus/stats/bucket_boundaries.h"
 #include "opencensus/stats/internal/aggregation_window.h"
+#include "opencensus/stats/measure.h"
 #include "opencensus/stats/measure_descriptor.h"
-#include "opencensus/stats/measure_registry.h"
 #include "opencensus/stats/view_descriptor.h"
 
 namespace opencensus {
@@ -45,10 +45,10 @@ TEST(DebugStringTest, AggregationWindow) {
 
 TEST(DebugStringTest, MeasureDescriptor) {
   const std::string name = "foo";
-  const std::string units = "ops";
   const std::string description = "Usage of foo";
+  const std::string units = "1";
   static const MeasureDescriptor descriptor =
-      MeasureRegistry::RegisterInt(name, units, description).GetDescriptor();
+      MeasureInt64::Register(name, description, units).GetDescriptor();
   EXPECT_PRED_FORMAT2(::testing::IsSubstring, name, descriptor.DebugString());
   EXPECT_PRED_FORMAT2(::testing::IsSubstring, units, descriptor.DebugString());
   EXPECT_PRED_FORMAT2(::testing::IsSubstring, description,
@@ -60,9 +60,9 @@ TEST(DebugStringTest, ViewDescriptor) {
   const AggregationWindow aggregation_window =
       AggregationWindow::Interval(absl::Minutes(1));
   const std::string measure_name = "bar";
-  static const MeasureDouble measure =
-      MeasureRegistry::RegisterDouble(measure_name, "", "");
+  static const auto measure = MeasureDouble::Register(measure_name, "", "");
   static const TagKey tag_key = TagKey::Register("tag_key_1");
+  MeasureDouble::Register(measure_name, "", "");
   const std::string description = "description string";
   ViewDescriptor descriptor = ViewDescriptor()
                                   .set_measure(measure_name)

--- a/opencensus/stats/internal/delta_producer_stats_test.cc
+++ b/opencensus/stats/internal/delta_producer_stats_test.cc
@@ -16,7 +16,6 @@
 #include "gtest/gtest.h"
 #include "opencensus/stats/internal/delta_producer.h"
 #include "opencensus/stats/measure.h"
-#include "opencensus/stats/measure_registry.h"
 #include "opencensus/stats/view.h"
 
 namespace opencensus {
@@ -27,14 +26,14 @@ constexpr char kFirstMeasureId[] = "first_measure_name";
 constexpr char kSecondMeasureId[] = "second_measure_name";
 
 MeasureDouble FirstMeasure() {
-  static MeasureDouble measure = MeasureRegistry::RegisterDouble(
-      kFirstMeasureId, "ops", "Usage of resource 1.");
+  static const auto measure =
+      MeasureDouble::Register(kFirstMeasureId, "Usage of resource 1.", "1");
   return measure;
 }
 
-MeasureInt SecondMeasure() {
-  static MeasureInt measure = MeasureRegistry::RegisterInt(
-      kSecondMeasureId, "ops", "Usage of resource 2.");
+MeasureInt64 SecondMeasure() {
+  static const auto measure =
+      MeasureInt64::Register(kSecondMeasureId, "Usage of resource 2.", "1");
   return measure;
 }
 
@@ -305,8 +304,7 @@ TEST(StatsManagerDeathTest, UnregisteredMeasure) {
   EXPECT_DEBUG_DEATH({ EXPECT_TRUE(view.GetData().int_data().empty()); }, "");
   // Even if we later register the measure and record data under it, the view
   // should still be invalid.
-  static MeasureDouble measure =
-      MeasureRegistry::RegisterDouble(measure_name, "", "");
+  static const auto measure = MeasureDouble::Register(measure_name, "", "");
   EXPECT_TRUE(measure.IsValid());
   ExperimentalDeltaProducerRecord({{measure, 1.0}});
   EXPECT_FALSE(view.IsValid());

--- a/opencensus/stats/internal/measure.cc
+++ b/opencensus/stats/internal/measure.cc
@@ -14,11 +14,21 @@
 
 #include "opencensus/stats/measure.h"
 
+#include "absl/strings/string_view.h"
 #include "opencensus/stats/internal/measure_registry_impl.h"
 #include "opencensus/stats/measure_registry.h"
 
 namespace opencensus {
 namespace stats {
+
+// static
+template <typename MeasureT>
+Measure<MeasureT> Measure<MeasureT>::Register(absl::string_view name,
+                                              absl::string_view description,
+                                              absl::string_view units) {
+  return MeasureRegistryImpl::Get()->Register<MeasureT>(name, description,
+                                                        units);
+}
 
 template <typename MeasureT>
 const MeasureDescriptor& Measure<MeasureT>::GetDescriptor() const {
@@ -35,7 +45,7 @@ bool MeasureDouble::IsValid() const {
 }
 
 template <>
-bool MeasureInt::IsValid() const {
+bool MeasureInt64::IsValid() const {
   return MeasureRegistryImpl::IdValid(id_) &&
          MeasureRegistryImpl::IdToType(id_) == MeasureDescriptor::Type::kInt64;
 }

--- a/opencensus/stats/internal/measure_registry.cc
+++ b/opencensus/stats/internal/measure_registry.cc
@@ -20,20 +20,6 @@ namespace opencensus {
 namespace stats {
 
 // static
-MeasureDouble MeasureRegistry::RegisterDouble(absl::string_view name,
-                                              absl::string_view units,
-                                              absl::string_view description) {
-  return MeasureRegistryImpl::Get()->RegisterDouble(name, units, description);
-}
-
-// static
-MeasureInt MeasureRegistry::RegisterInt(absl::string_view name,
-                                        absl::string_view units,
-                                        absl::string_view description) {
-  return MeasureRegistryImpl::Get()->RegisterInt(name, units, description);
-}
-
-// static
 const MeasureDescriptor& MeasureRegistry::GetDescriptorByName(
     absl::string_view name) {
   return MeasureRegistryImpl::Get()->GetDescriptorByName(name);
@@ -45,8 +31,8 @@ MeasureDouble MeasureRegistry::GetMeasureDoubleByName(absl::string_view name) {
 }
 
 // static
-MeasureInt MeasureRegistry::GetMeasureIntByName(absl::string_view name) {
-  return MeasureRegistryImpl::Get()->GetMeasureIntByName(name);
+MeasureInt64 MeasureRegistry::GetMeasureInt64ByName(absl::string_view name) {
+  return MeasureRegistryImpl::Get()->GetMeasureInt64ByName(name);
 }
 
 }  // namespace stats

--- a/opencensus/stats/internal/measure_registry_impl.cc
+++ b/opencensus/stats/internal/measure_registry_impl.cc
@@ -18,6 +18,7 @@
 
 #include "opencensus/stats/internal/delta_producer.h"
 #include "opencensus/stats/internal/stats_manager.h"
+#include "opencensus/stats/measure_descriptor.h"
 
 namespace opencensus {
 namespace stats {
@@ -41,11 +42,12 @@ MeasureRegistryImpl* MeasureRegistryImpl::Get() {
   return global_measure_registry_impl;
 }
 
-MeasureDouble MeasureRegistryImpl::RegisterDouble(
-    absl::string_view name, absl::string_view units,
-    absl::string_view description) {
+template <>
+MeasureDouble MeasureRegistryImpl::Register(absl::string_view name,
+                                            absl::string_view description,
+                                            absl::string_view units) {
   MeasureDouble measure(RegisterImpl(MeasureDescriptor(
-      name, units, description, MeasureDescriptor::Type::kDouble)));
+      name, description, units, MeasureDescriptor::Type::kDouble)));
   if (measure.IsValid()) {
     StatsManager::Get()->AddMeasure(measure);
     DeltaProducer::Get()->AddMeasure();
@@ -53,11 +55,12 @@ MeasureDouble MeasureRegistryImpl::RegisterDouble(
   return measure;
 }
 
-MeasureInt MeasureRegistryImpl::RegisterInt(absl::string_view name,
-                                            absl::string_view units,
-                                            absl::string_view description) {
-  MeasureInt measure(RegisterImpl(MeasureDescriptor(
-      name, units, description, MeasureDescriptor::Type::kInt64)));
+template <>
+MeasureInt64 MeasureRegistryImpl::Register(absl::string_view name,
+                                           absl::string_view description,
+                                           absl::string_view units) {
+  MeasureInt64 measure(RegisterImpl(MeasureDescriptor(
+      name, description, units, MeasureDescriptor::Type::kInt64)));
   if (measure.IsValid()) {
     StatsManager::Get()->AddMeasure(measure);
     DeltaProducer::Get()->AddMeasure();
@@ -109,15 +112,15 @@ MeasureDouble MeasureRegistryImpl::GetMeasureDoubleByName(
   }
 }
 
-MeasureInt MeasureRegistryImpl::GetMeasureIntByName(
+MeasureInt64 MeasureRegistryImpl::GetMeasureInt64ByName(
     absl::string_view name) const {
   absl::ReaderMutexLock l(&mu_);
   const auto it = id_map_.find(std::string(name));
   if (it == id_map_.end()) {
-    return MeasureInt(
+    return MeasureInt64(
         CreateMeasureId(0, false, MeasureDescriptor::Type::kDouble));
   } else {
-    return MeasureInt(it->second);
+    return MeasureInt64(it->second);
   }
 }
 

--- a/opencensus/stats/internal/measure_registry_impl.h
+++ b/opencensus/stats/internal/measure_registry_impl.h
@@ -35,18 +35,17 @@ class MeasureRegistryImpl {
  public:
   static MeasureRegistryImpl* Get();
 
-  MeasureDouble RegisterDouble(absl::string_view name, absl::string_view units,
-                               absl::string_view description)
-      LOCKS_EXCLUDED(mu_);
-  MeasureInt RegisterInt(absl::string_view name, absl::string_view units,
-                         absl::string_view description) LOCKS_EXCLUDED(mu_);
+  template <typename MeasureT>
+  Measure<MeasureT> Register(absl::string_view name,
+                             absl::string_view description,
+                             absl::string_view units) LOCKS_EXCLUDED(mu_);
 
   const MeasureDescriptor& GetDescriptorByName(absl::string_view name) const
       LOCKS_EXCLUDED(mu_);
 
   MeasureDouble GetMeasureDoubleByName(absl::string_view name) const
       LOCKS_EXCLUDED(mu_);
-  MeasureInt GetMeasureIntByName(absl::string_view name) const
+  MeasureInt64 GetMeasureInt64ByName(absl::string_view name) const
       LOCKS_EXCLUDED(mu_);
 
   // The following methods are for internal use by the library, and not exposed
@@ -81,6 +80,16 @@ class MeasureRegistryImpl {
   // A map from measure names to IDs.
   std::unordered_map<std::string, uint64_t> id_map_ GUARDED_BY(mu_);
 };
+
+template <>
+MeasureDouble MeasureRegistryImpl::Register(absl::string_view name,
+                                            absl::string_view description,
+                                            absl::string_view units);
+
+template <>
+MeasureInt64 MeasureRegistryImpl::Register(absl::string_view name,
+                                           absl::string_view description,
+                                           absl::string_view units);
 
 template <typename MeasureT>
 const MeasureDescriptor& MeasureRegistryImpl::GetDescriptor(

--- a/opencensus/stats/internal/measure_registry_test.cc
+++ b/opencensus/stats/internal/measure_registry_test.cc
@@ -33,47 +33,46 @@ std::string MakeUniqueName() {
 
 TEST(MeasureRegistryTest, RegisterDouble) {
   const std::string name = MakeUniqueName();
-  const std::string units = "units";
   const std::string description = "description";
+  const std::string units = "units";
 
-  MeasureDouble measure =
-      MeasureRegistry::RegisterDouble(name, units, description);
+  MeasureDouble measure = MeasureDouble::Register(name, description, units);
   ASSERT_TRUE(measure.IsValid());
   const MeasureDescriptor& descriptor = measure.GetDescriptor();
   EXPECT_EQ(name, descriptor.name());
-  EXPECT_EQ(units, descriptor.units());
   EXPECT_EQ(description, descriptor.description());
+  EXPECT_EQ(units, descriptor.units());
   EXPECT_EQ(MeasureDescriptor::Type::kDouble, descriptor.type());
 }
 
 TEST(MeasureRegistryTest, RegisterInt) {
   const std::string name = MakeUniqueName();
-  const std::string units = "units";
   const std::string description = "description";
+  const std::string units = "units";
 
-  MeasureInt measure = MeasureRegistry::RegisterInt(name, units, description);
+  MeasureInt64 measure = MeasureInt64::Register(name, description, units);
   ASSERT_TRUE(measure.IsValid());
   const MeasureDescriptor& descriptor = measure.GetDescriptor();
   EXPECT_EQ(name, descriptor.name());
-  EXPECT_EQ(units, descriptor.units());
   EXPECT_EQ(description, descriptor.description());
+  EXPECT_EQ(units, descriptor.units());
   EXPECT_EQ(MeasureDescriptor::Type::kInt64, descriptor.type());
 }
 
 TEST(MeasureRegistryTest, RegisteringEmptyNameFails) {
-  EXPECT_FALSE(MeasureRegistry::RegisterDouble("", "", "").IsValid());
+  EXPECT_FALSE(MeasureDouble::Register("", "", "").IsValid());
 }
 
 TEST(MeasureRegistryTest, DuplicateRegistrationsFail) {
   const std::string name = MakeUniqueName();
   const std::string units = "units";
 
-  MeasureDouble measure = MeasureRegistry::RegisterDouble(name, units, "");
+  MeasureDouble measure = MeasureDouble::Register(name, "", units);
   ASSERT_TRUE(measure.IsValid());
 
   // Subsequent registrations should fail, regardless of type.
-  EXPECT_FALSE(MeasureRegistry::RegisterDouble(name, "", "").IsValid());
-  EXPECT_FALSE(MeasureRegistry::RegisterInt(name, "", "").IsValid());
+  EXPECT_FALSE(MeasureDouble::Register(name, "", "").IsValid());
+  EXPECT_FALSE(MeasureInt64::Register(name, "", "").IsValid());
 
   // The descriptor should not have been updated.
   EXPECT_EQ(units, measure.GetDescriptor().units());
@@ -81,11 +80,10 @@ TEST(MeasureRegistryTest, DuplicateRegistrationsFail) {
 
 TEST(MeasureRegistryTest, GetDescriptorByName) {
   const std::string name = MakeUniqueName();
-  const std::string units = "units";
   const std::string description = "description";
+  const std::string units = "units";
 
-  MeasureDouble measure =
-      MeasureRegistry::RegisterDouble(name, units, description);
+  MeasureDouble measure = MeasureDouble::Register(name, description, units);
   ASSERT_TRUE(measure.IsValid());
   EXPECT_EQ(measure.GetDescriptor(),
             MeasureRegistry::GetDescriptorByName(name));
@@ -101,7 +99,7 @@ TEST(MeasureRegistryTest, GetDescriptorByNameWithUnregisteredName) {
 
 TEST(MeasureRegistryTest, GetMeasureDoubleByName) {
   const std::string name = MakeUniqueName();
-  MeasureDouble measure1 = MeasureRegistry::RegisterDouble(name, "", "");
+  MeasureDouble measure1 = MeasureDouble::Register(name, "", "");
   ASSERT_TRUE(measure1.IsValid());
 
   MeasureDouble measure2 = MeasureRegistry::GetMeasureDoubleByName(name);
@@ -110,12 +108,12 @@ TEST(MeasureRegistryTest, GetMeasureDoubleByName) {
   EXPECT_EQ(measure1.GetDescriptor(), measure2.GetDescriptor());
 }
 
-TEST(MeasureRegistryTest, GetMeasureIntByName) {
+TEST(MeasureRegistryTest, GetMeasureInt64ByName) {
   const std::string name = MakeUniqueName();
-  MeasureInt measure1 = MeasureRegistry::RegisterInt(name, "", "");
+  MeasureInt64 measure1 = MeasureInt64::Register(name, "", "");
   ASSERT_TRUE(measure1.IsValid());
 
-  MeasureInt measure2 = MeasureRegistry::GetMeasureIntByName(name);
+  MeasureInt64 measure2 = MeasureRegistry::GetMeasureInt64ByName(name);
   ASSERT_TRUE(measure2.IsValid());
   EXPECT_EQ(measure1, measure2);
   EXPECT_EQ(measure1.GetDescriptor(), measure2.GetDescriptor());
@@ -126,20 +124,19 @@ TEST(MeasureRegistryTest, GetMeasureDoubleUnregisteredFails) {
       MeasureRegistry::GetMeasureDoubleByName(MakeUniqueName()).IsValid());
 }
 
-TEST(MeasureRegistryTest, GetMeasureIntUnregisteredFails) {
+TEST(MeasureRegistryTest, GetMeasureInt64UnregisteredFails) {
   EXPECT_FALSE(
-      MeasureRegistry::GetMeasureIntByName(MakeUniqueName()).IsValid());
+      MeasureRegistry::GetMeasureInt64ByName(MakeUniqueName()).IsValid());
 }
 
 TEST(MeasureRegistryTest, GetMeasureByNameWithWrongTypeFails) {
   const std::string double_name = MakeUniqueName();
   const std::string int_name = MakeUniqueName();
-  MeasureDouble measure_double =
-      MeasureRegistry::RegisterDouble(double_name, "", "");
-  MeasureInt measure_int = MeasureRegistry::RegisterInt(int_name, "", "");
+  MeasureDouble measure_double = MeasureDouble::Register(double_name, "", "");
+  MeasureInt64 measure_int = MeasureInt64::Register(int_name, "", "");
 
-  MeasureInt measure_double_mistyped =
-      MeasureRegistry::GetMeasureIntByName(double_name);
+  MeasureInt64 measure_double_mistyped =
+      MeasureRegistry::GetMeasureInt64ByName(double_name);
   EXPECT_FALSE(measure_double_mistyped.IsValid());
   EXPECT_NE(measure_double.GetDescriptor(),
             measure_double_mistyped.GetDescriptor());

--- a/opencensus/stats/internal/stats_exporter_test.cc
+++ b/opencensus/stats/internal/stats_exporter_test.cc
@@ -26,7 +26,6 @@
 #include "opencensus/stats/internal/set_aggregation_window.h"
 #include "opencensus/stats/measure.h"
 #include "opencensus/stats/measure_descriptor.h"
-#include "opencensus/stats/measure_registry.h"
 #include "opencensus/stats/view_descriptor.h"
 
 namespace opencensus {
@@ -60,8 +59,7 @@ class MockExporter : public StatsExporter::Handler {
 constexpr char kMeasureId[] = "test_measure_id";
 
 MeasureDouble TestMeasure() {
-  static MeasureDouble measure =
-      MeasureRegistry::RegisterDouble(kMeasureId, "ops", "");
+  static MeasureDouble measure = MeasureDouble::Register(kMeasureId, "", "1");
   return measure;
 }
 

--- a/opencensus/stats/internal/stats_manager.cc
+++ b/opencensus/stats/internal/stats_manager.cc
@@ -25,6 +25,7 @@
 #include "opencensus/stats/bucket_boundaries.h"
 #include "opencensus/stats/internal/delta_producer.h"
 #include "opencensus/stats/internal/measure_data.h"
+#include "opencensus/stats/internal/measure_registry_impl.h"
 #include "opencensus/stats/tag_key.h"
 #include "opencensus/stats/tag_set.h"
 #include "opencensus/stats/view_descriptor.h"
@@ -215,7 +216,7 @@ void StatsManager::AddMeasure(Measure<MeasureT> measure) {
 }
 
 template void StatsManager::AddMeasure(MeasureDouble measure);
-template void StatsManager::AddMeasure(MeasureInt measure);
+template void StatsManager::AddMeasure(MeasureInt64 measure);
 
 StatsManager::ViewInformation* StatsManager::AddConsumer(
     const ViewDescriptor& descriptor) {

--- a/opencensus/stats/internal/stats_manager.h
+++ b/opencensus/stats/internal/stats_manager.h
@@ -24,7 +24,6 @@
 #include "opencensus/stats/distribution.h"
 #include "opencensus/stats/internal/delta_producer.h"
 #include "opencensus/stats/internal/measure_data.h"
-#include "opencensus/stats/internal/measure_registry_impl.h"
 #include "opencensus/stats/internal/view_data_impl.h"
 #include "opencensus/stats/measure.h"
 #include "opencensus/stats/tag_key.h"
@@ -149,7 +148,7 @@ class StatsManager final {
 };
 
 extern template void StatsManager::AddMeasure(MeasureDouble measure);
-extern template void StatsManager::AddMeasure(MeasureInt measure);
+extern template void StatsManager::AddMeasure(MeasureInt64 measure);
 
 }  // namespace stats
 }  // namespace opencensus

--- a/opencensus/stats/internal/stats_manager_benchmark.cc
+++ b/opencensus/stats/internal/stats_manager_benchmark.cc
@@ -22,7 +22,6 @@
 #include "opencensus/stats/internal/aggregation_window.h"
 #include "opencensus/stats/internal/set_aggregation_window.h"
 #include "opencensus/stats/measure.h"
-#include "opencensus/stats/measure_registry.h"
 #include "opencensus/stats/recording.h"
 #include "opencensus/stats/view.h"
 #include "opencensus/stats/view_descriptor.h"
@@ -76,7 +75,7 @@ void BM_Record(benchmark::State& state) {
   const TagKey tag_key_1 = TagKey::Register("tag_key_1");
   const TagKey tag_key_2 = TagKey::Register("tag_key_2");
   const std::string measure_name = MakeUniqueName();
-  MeasureDouble measure = MeasureRegistry::RegisterDouble(measure_name, "", "");
+  MeasureDouble measure = MeasureDouble::Register(measure_name, "", "");
   std::vector<std::unique_ptr<View>> views;
   for (int i = 0; i < state.range(0); ++i) {
     // This tag key is necessary to prevent these from being merged by
@@ -126,7 +125,7 @@ void BM_RecordBatched(benchmark::State& state) {
   std::vector<std::unique_ptr<View>> views;
   for (int i = 0; i < num_measures; ++i) {
     const std::string measure_name = MakeUniqueName();
-    measures.push_back(MeasureRegistry::RegisterDouble(measure_name, "", ""));
+    measures.push_back(MeasureDouble::Register(measure_name, "", ""));
 
     const ViewDescriptor count_descriptor =
         ViewDescriptor()

--- a/opencensus/stats/internal/stats_manager_test.cc
+++ b/opencensus/stats/internal/stats_manager_test.cc
@@ -16,7 +16,6 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "opencensus/stats/measure.h"
-#include "opencensus/stats/measure_registry.h"
 #include "opencensus/stats/recording.h"
 #include "opencensus/stats/tag_key.h"
 #include "opencensus/stats/view.h"
@@ -29,14 +28,14 @@ constexpr char kFirstMeasureId[] = "first_measure_name";
 constexpr char kSecondMeasureId[] = "second_measure_name";
 
 MeasureDouble FirstMeasure() {
-  static MeasureDouble measure = MeasureRegistry::RegisterDouble(
-      kFirstMeasureId, "ops", "Usage of resource 1.");
+  static MeasureDouble measure =
+      MeasureDouble::Register(kFirstMeasureId, "Usage of resource 1.", "1");
   return measure;
 }
 
-MeasureInt SecondMeasure() {
-  static MeasureInt measure = MeasureRegistry::RegisterInt(
-      kSecondMeasureId, "ops", "Usage of resource 2.");
+MeasureInt64 SecondMeasure() {
+  static MeasureInt64 measure =
+      MeasureInt64::Register(kSecondMeasureId, "Usage of resource 2.", "1");
   return measure;
 }
 
@@ -308,8 +307,7 @@ TEST(StatsManagerDeathTest, UnregisteredMeasure) {
   EXPECT_DEBUG_DEATH({ EXPECT_TRUE(view.GetData().int_data().empty()); }, "");
   // Even if we later register the measure and record data under it, the view
   // should still be invalid.
-  static MeasureDouble measure =
-      MeasureRegistry::RegisterDouble(measure_name, "", "");
+  static MeasureDouble measure = MeasureDouble::Register(measure_name, "", "");
   EXPECT_TRUE(measure.IsValid());
   Record({{measure, 1.0}});
   EXPECT_FALSE(view.IsValid());

--- a/opencensus/stats/measure_descriptor.h
+++ b/opencensus/stats/measure_descriptor.h
@@ -36,15 +36,15 @@ class MeasureDescriptor final {
   // See documentation on MeasureRegistry::Register*() for details of these
   // fields.
   const std::string& name() const { return name_; }
-  const std::string& units() const { return units_; }
   const std::string& description() const { return description_; }
+  const std::string& units() const { return units_; }
   Type type() const { return type_; }
 
   std::string DebugString() const;
 
   bool operator==(const MeasureDescriptor& other) const {
-    return name_ == other.name_ && units_ == other.units_ &&
-           description_ == other.description_ && type_ == other.type_;
+    return name_ == other.name_ && description_ == other.description_ &&
+           units_ == other.units_ && type_ == other.type_;
   }
   bool operator!=(const MeasureDescriptor& other) const {
     return !(*this == other);
@@ -54,13 +54,13 @@ class MeasureDescriptor final {
   // Only MeasureRegistryImpl can construct this--users should call the
   // MeasureRegistry::Register*() functions.
   friend class MeasureRegistryImpl;
-  MeasureDescriptor(absl::string_view name, absl::string_view units,
-                    absl::string_view description, Type type)
-      : name_(name), units_(units), description_(description), type_(type) {}
+  MeasureDescriptor(absl::string_view name, absl::string_view description,
+                    absl::string_view units, Type type)
+      : name_(name), description_(description), units_(units), type_(type) {}
 
   const std::string name_;
-  const std::string units_;
   const std::string description_;
+  const std::string units_;
   const Type type_;
 };
 

--- a/opencensus/stats/measure_registry.h
+++ b/opencensus/stats/measure_registry.h
@@ -22,37 +22,11 @@ namespace opencensus {
 namespace stats {
 
 // The MeasureRegistry keeps a record of all MeasureDescriptors registered,
-// providing functions for registering measures and querying their metadata by
-// name or handle.
+// providing functions for querying their metadata by name or handle. Use
+// Measure<MeasureT>::Register() to register a measure with the registry.
 // MeasureRegistry is thread-safe.
 class MeasureRegistry final {
  public:
-  // Registers a MeasureDescriptor, returning a Measure that can be used to
-  // record values for or create views on that measure. Only one Measure may be
-  // registered under a certain name; subsequent registrations will fail,
-  // returning an invalid measure. Register* functions should only be called by
-  // the owner of a measure--other users should use GetMeasureByName. If there
-  // are multiple competing owners (e.g. for a generic resource such as "RPC
-  // latency" shared between RPC libraries) check whether the measure is
-  // registered with GetMeasure*ByName before registering it.
-  //
-  // 'name' should be a globally unique identifier. It is recommended that this
-  //   be in the format "<domain>/<path>", e.g. "example.com/client/foo_usage".
-  // 'units' are the units of recorded values. The recommended grammar is:
-  //     - Expression = Component { "." Component } {"/" Component }
-  //     - Component = [ PREFIX ] UNIT [ Annotation ] | Annotation | "1"
-  //     - Annotation = "{" NAME "}"
-  //   For example, string “MBy{transmitted}/ms” stands for megabytes per
-  //   milliseconds, and the annotation transmitted inside {} is just a comment
-  //   of the unit.
-  // 'description' is a human-readable description of what the measure's
-  //   values represent.
-  static MeasureDouble RegisterDouble(absl::string_view name,
-                                      absl::string_view units,
-                                      absl::string_view description);
-  static MeasureInt RegisterInt(absl::string_view name, absl::string_view units,
-                                absl::string_view description);
-
   // Returns the descriptor of the measure registered under 'name' if one is
   // registered, and a descriptor with an empty name otherwise.
   static const MeasureDescriptor& GetDescriptorByName(absl::string_view name);
@@ -60,7 +34,7 @@ class MeasureRegistry final {
   // Returns a measure for the registered MeasureDescriptor with the
   // provided name, if one exists, and an invalid Measure otherwise.
   static MeasureDouble GetMeasureDoubleByName(absl::string_view name);
-  static MeasureInt GetMeasureIntByName(absl::string_view name);
+  static MeasureInt64 GetMeasureInt64ByName(absl::string_view name);
 };
 
 }  // namespace stats

--- a/opencensus/stats/recording.h
+++ b/opencensus/stats/recording.h
@@ -31,8 +31,8 @@ namespace stats {
 //   Record({{measure_double, 2.5}, {measure_int, 1ll}});
 //
 // Only floating point values may be recorded against MeasureDoubles and only
-// integral values against MeasureInts, to prevent silent loss of precision. If
-// a record call fails to compile, ensure that all types match (using
+// integral values against MeasureInt64s, to prevent silent loss of precision.
+// If a record call fails to compile, ensure that all types match (using
 // static_cast to double or int64_t if necessary).
 void Record(
     std::initializer_list<Measurement> measurements,


### PR DESCRIPTION
This completes moving away from direct interaction with the registries in the core stats workflows (after moving RegisterForExport from the StatsExporter to the ViewDescriptor). 

After this, the only use keeping MeasureRegistry in the public API is the possibility of measures shared between libraries with no common initialization (e.g. an rpc_latency measure shared between RPC libraries), for which we presently encourage looking up the measure and registering it if not found. I think we should consider recommending that such libraries either use individual measures or depend on a common measure definition package and make MeasureRegistry internal.