### PR TITLE
Increase Stackdriver CreateTimeSeries batch size.

### DIFF
--- a/opencensus/exporters/stats/stackdriver/internal/stackdriver_e2e_test.cc
+++ b/opencensus/exporters/stats/stackdriver/internal/stackdriver_e2e_test.cc
@@ -224,8 +224,9 @@ TEST_F(StackdriverE2eTest, LargeTest) {
       count_matchers;
 
   // The number of values to record for each tag--total metric cardinality will
-  // be tag_values^2.
-  const int tag_values = 10;
+  // be tag_values^2. We want this high enough that uploads require multiple
+  // batches.
+  const int tag_values = 25;
   for (int i = 0; i < tag_values; ++i) {
     for (int j = 0; j < tag_values; ++j) {
       const std::string tag1 = absl::StrCat("v1", i);

--- a/opencensus/exporters/stats/stackdriver/internal/stackdriver_exporter.cc
+++ b/opencensus/exporters/stats/stackdriver/internal/stackdriver_exporter.cc
@@ -31,7 +31,8 @@ namespace {
 
 constexpr char kGoogleStackdriverStatsAddress[] = "monitoring.googleapis.com";
 constexpr char kProjectIdPrefix[] = "projects/";
-constexpr int kTimeSeriesBatchSize = 3;
+// Stackdriver limits a single CreateTimeSeries request to 200 series.
+constexpr int kTimeSeriesBatchSize = 200;
 
 std::string ToString(const grpc::Status& status) {
   return absl::StrCat("status code ", status.error_code(), " details \"",


### PR DESCRIPTION
Stackdriver has fixed the backend limitations that constrained this previously. I ran the expanded e2e test locally.