### PR TITLE
Bring back SpanExporter::ExportForTesting.

### DIFF
--- a/opencensus/exporters/trace/stdout/internal/stdout_exporter.cc
+++ b/opencensus/exporters/trace/stdout/internal/stdout_exporter.cc
@@ -25,23 +25,28 @@
 namespace opencensus {
 namespace exporters {
 namespace trace {
+namespace {
 
-class StdoutExporter::Handler
-    : public ::opencensus::trace::exporter::SpanExporter::Handler {
+class Handler : public ::opencensus::trace::exporter::SpanExporter::Handler {
+ public:
+  Handler(std::ostream* stream) : stream_(stream) {}
+
   void Export(const std::vector<::opencensus::trace::exporter::SpanData>& spans)
-      override;
+      override {
+    for (const auto& span : spans) {
+      *stream_ << span.DebugString() << "\n";
+    }
+  }
+
+ private:
+  std::ostream* stream_;
 };
 
-void StdoutExporter::Handler::Export(
-    const std::vector<::opencensus::trace::exporter::SpanData>& spans) {
-  for (const auto& span : spans) {
-    std::cout << span.DebugString() << "\n";
-  }
-}
+}  // namespace
 
-void StdoutExporter::Register() {
+void StdoutExporter::Register(std::ostream* stream) {
   ::opencensus::trace::exporter::SpanExporter::RegisterHandler(
-      absl::make_unique<Handler>());
+      absl::make_unique<Handler>(stream));
 }
 
 }  // namespace trace

--- a/opencensus/exporters/trace/stdout/stdout_exporter.h
+++ b/opencensus/exporters/trace/stdout/stdout_exporter.h
@@ -15,16 +15,16 @@
 #ifndef OPENCENSUS_EXPORTERS_TRACE_STDOUT_STDOUT_EXPORTER_H_
 #define OPENCENSUS_EXPORTERS_TRACE_STDOUT_STDOUT_EXPORTER_H_
 
+#include <iostream>
+
 namespace opencensus {
 namespace exporters {
 namespace trace {
 
 class StdoutExporter {
  public:
-  static void Register();
-
- private:
-  class Handler;
+  StdoutExporter() = delete;
+  static void Register(std::ostream* stream = &std::cout);
 };
 
 }  // namespace trace

--- a/opencensus/trace/exporter/span_exporter.h
+++ b/opencensus/trace/exporter/span_exporter.h
@@ -24,13 +24,11 @@ namespace opencensus {
 namespace trace {
 namespace exporter {
 
-class SpanExporterImpl;
-
-// SpanExporter tracks Exporters. Thread-safe.
+// SpanExporter allows Exporters to register. Thread-safe.
 class SpanExporter final {
  public:
   // Handlers allow different tracing services to export recorded data for
-  // sampled spans in their own format. The exporter should provide a static
+  // sampled spans in their own format. Every exporter must provide a static
   // Register() method that takes any arguments needed by the exporter (e.g. a
   // URL to export to) and calls SpanExporter::RegisterHandler itself.
   class Handler {
@@ -41,6 +39,12 @@ class SpanExporter final {
 
   // This should only be called by Handler's Register() method.
   static void RegisterHandler(std::unique_ptr<Handler> handler);
+
+ private:
+  friend class SpanExporterTestPeer;
+
+  // Forces an export, only for testing purposes.
+  static void ExportForTesting();
 };
 
 }  // namespace exporter

--- a/opencensus/trace/internal/span_exporter.cc
+++ b/opencensus/trace/internal/span_exporter.cc
@@ -23,8 +23,14 @@ namespace opencensus {
 namespace trace {
 namespace exporter {
 
+// static
 void SpanExporter::RegisterHandler(std::unique_ptr<Handler> handler) {
   SpanExporterImpl::Get()->RegisterHandler(std::move(handler));
+}
+
+// static
+void SpanExporter::ExportForTesting() {
+  SpanExporterImpl::Get()->ExportForTesting();
 }
 
 }  // namespace exporter

--- a/opencensus/trace/internal/span_exporter_impl.h
+++ b/opencensus/trace/internal/span_exporter_impl.h
@@ -49,6 +49,7 @@ class SpanExporterImpl {
   // SpanData will take place at a later time via the background thread. This
   // is intended to be called at the Span::End().
   void AddSpan(const std::shared_ptr<opencensus::trace::SpanImpl>& span_impl);
+
   // Registers a handler with the exporter. This is intended to be done at
   // initialization.
   void RegisterHandler(std::unique_ptr<SpanExporter::Handler> handler);
@@ -63,6 +64,7 @@ class SpanExporterImpl {
   SpanExporterImpl& operator=(const SpanExporterImpl&) = delete;
   SpanExporterImpl& operator=(SpanExporterImpl&&) = delete;
   friend class Span;
+  friend class SpanExporter;  // For ExportForTesting() only.
 
   void StartExportThread() EXCLUSIVE_LOCKS_REQUIRED(handler_mu_);
   void RunWorkerLoop();
@@ -70,6 +72,8 @@ class SpanExporterImpl {
   // Calls all registered handlers and exports the spans contained in span_data.
   void Export(const std::vector<SpanData>& span_data);
 
+  // Only for testing purposes: runs the export on the current thread and
+  // returns when complete.
   void ExportForTesting();
 
   // Returns true if the spans_ buffer has filled up.


### PR DESCRIPTION
- Make StdoutExporter take an ostream.

- Make stdout_exporter_test faster (no sleep) and check that
  the added annotation appears in the output.