### PR TITLE
Remove MeasureData::Add(), only used in tests.

### DIFF
--- a/opencensus/stats/internal/measure_data.cc
+++ b/opencensus/stats/internal/measure_data.cc
@@ -77,8 +77,14 @@ void MeasureData::AddToDistribution(const BucketBoundaries& boundaries,
   *count = new_count;
   *mean = new_mean;
 
-  *min = std::min(*min, min_);
-  *max = std::max(*max, max_);
+  if (*count == count_) {
+    // Overwrite in case the destination was zero-initialized.
+    *min = min_;
+    *max = max_;
+  } else {
+    *min = std::min(*min, min_);
+    *max = std::max(*max, max_);
+  }
 
   int histogram_index =
       std::find(boundaries_.begin(), boundaries_.end(), boundaries) -

--- a/opencensus/stats/internal/measure_data.h
+++ b/opencensus/stats/internal/measure_data.h
@@ -51,7 +51,7 @@ class MeasureData final {
                          absl::Span<T> histogram_buckets) const;
 
  private:
-  absl::Span<const BucketBoundaries> boundaries_;
+  const absl::Span<const BucketBoundaries> boundaries_;
 
   uint64_t count_ = 0;
   double mean_ = 0;

--- a/opencensus/stats/internal/view_data_impl.cc
+++ b/opencensus/stats/internal/view_data_impl.cc
@@ -167,56 +167,6 @@ ViewDataImpl::ViewDataImpl(const ViewDataImpl& other)
   }
 }
 
-void ViewDataImpl::Add(double value, const std::vector<std::string>& tag_values,
-                       absl::Time now) {
-  end_time_ = std::max(end_time_, now);
-  switch (type_) {
-    case Type::kDouble: {
-      double_data_[tag_values] += value;
-      break;
-    }
-    case Type::kInt64: {
-      int_data_[tag_values] +=
-          (aggregation_.type() == Aggregation::Type::kSum ? value : 1);
-      break;
-    }
-    case Type::kDistribution: {
-      DataMap<Distribution>::iterator it = distribution_data_.find(tag_values);
-      if (it == distribution_data_.end()) {
-        it = distribution_data_.emplace_hint(
-            it, tag_values, Distribution(&aggregation_.bucket_boundaries()));
-      }
-      it->second.Add(value);
-      break;
-    }
-    case Type::kStatsObject: {
-      DataMap<IntervalStatsObject>::iterator it =
-          interval_data_.find(tag_values);
-      if (aggregation_.type() == Aggregation::Type::kDistribution) {
-        const auto& buckets = aggregation_.bucket_boundaries();
-        if (it == interval_data_.end()) {
-          it = interval_data_.emplace_hint(
-              it, std::piecewise_construct, std::make_tuple(tag_values),
-              std::make_tuple(buckets.num_buckets() + 5,
-                              aggregation_window_.duration(), now));
-        }
-        it->second.AddToDistribution(value, buckets.BucketForValue(value), now);
-      } else {
-        if (it == interval_data_.end()) {
-          it = interval_data_.emplace_hint(
-              it, std::piecewise_construct, std::make_tuple(tag_values),
-              std::make_tuple(1, aggregation_window_.duration(), now));
-        }
-        if (aggregation_ == Aggregation::Count()) {
-          it->second.MutableCurrentBucket(now)[0] += 1.0;
-        } else {
-          it->second.MutableCurrentBucket(now)[0] += value;
-        }
-      }
-    }
-  }
-}
-
 void ViewDataImpl::Merge(const std::vector<std::string>& tag_values,
                          const MeasureData& data, absl::Time now) {
   end_time_ = std::max(end_time_, now);

--- a/opencensus/stats/internal/view_data_impl.h
+++ b/opencensus/stats/internal/view_data_impl.h
@@ -106,13 +106,6 @@ class ViewDataImpl {
   absl::Time start_time() const { return start_time_; }
   absl::Time end_time() const { return end_time_; }
 
-  // Adds data for the given tag values at 'now'. tag_values must be ordered
-  // according to the order of keys in the ViewDescriptor.
-  // TODO: Change to take Span<string_view> when heterogenous lookup is
-  // supported.
-  void Add(double value, const std::vector<std::string>& tag_values,
-           absl::Time now);
-
   // Merges bulk data for the given tag values at 'now'. tag_values must be
   // ordered according to the order of keys in the ViewDescriptor.
   // TODO: Change to take Span<string_view> when heterogenous lookup is


### PR DESCRIPTION
And fix a bug revealed in AddToDistribution with StatsObjects.