### PR TITLE
We no longer have to filter out targets with underscores.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,5 +14,5 @@ before_install:
 script:
   # We can't use --noshow_progress because Travis terminates the
   # build after 10 mins without output.
-  - bazel build $BAZEL_OPTIONS --experimental_ui_actions_shown=1 -k $(bazel query "kind(rule, //...)" | grep -v :_)
-  - bazel test $BAZEL_OPTIONS --experimental_ui_actions_shown=1 -k $(bazel query "kind(test, //...) except attr('tags', 'manual|noci', //...)" | grep -v :_)
+  - bazel build $BAZEL_OPTIONS --experimental_ui_actions_shown=1 -k //...
+  - bazel test $BAZEL_OPTIONS --experimental_ui_actions_shown=1 -k $(bazel query "kind(test, //...) except attr('tags', 'manual|noci', //...)")


### PR DESCRIPTION
Since the cc_grpc_library() rule was fixed in
https://github.com/grpc/grpc/pull/14625