### PR TITLE
Mark some unused things as unused to quiet warnings.

### DIFF
--- a/opencensus/exporters/stats/prometheus/internal/prometheus_utils.cc
+++ b/opencensus/exporters/stats/prometheus/internal/prometheus_utils.cc
@@ -86,8 +86,10 @@ void SetValue(int64_t value, prometheus::MetricType type,
       ABSL_ASSERT(false && "Invalid MetricType for int64 value.");
   }
 }
+
 void SetValue(const opencensus::stats::Distribution& value,
-              prometheus::MetricType type, prometheus::ClientMetric* metric) {
+              prometheus::MetricType type ABSL_ATTRIBUTE_UNUSED,
+              prometheus::ClientMetric* metric) {
   auto& histogram = metric->histogram;
   histogram.sample_count = value.count();
   histogram.sample_sum = value.count() * value.mean();

--- a/opencensus/exporters/trace/zipkin/internal/zipkin_exporter.cc
+++ b/opencensus/exporters/trace/zipkin/internal/zipkin_exporter.cc
@@ -365,7 +365,7 @@ void ZipkinExportHandler::Export(
 
 void ZipkinExporter::Register(const ZipkinExporterOptions& options) {
   // Initialize libcurl. This MUST only be done once per process.
-  static CurlEnv* curl_lib = new CurlEnv();
+  static CurlEnv* curl_lib ABSL_ATTRIBUTE_UNUSED = new CurlEnv();
 
   // Create new exporter.
   ZipkinExportHandler* handler = new ZipkinExportHandler(options);


### PR DESCRIPTION
No functional change.