### PR TITLE
Document that Measure/TagKey have trivial destructors.

### DIFF
--- a/opencensus/stats/measure.h
+++ b/opencensus/stats/measure.h
@@ -27,7 +27,8 @@ namespace stats {
 // that measure can retrieve the data for those events. Measures can only be
 // obtained from the static functions MeasureRegistry::Register() and
 // MeasureRegistry::GetMeasureByName().
-// Measure is immutable, and should be passed by value.
+// Measure is immutable, and should be passed by value. It has a trivial
+// destructor and can be safely used as a local static variable.
 template <typename MeasureT>
 class Measure final {
  public:

--- a/opencensus/stats/tag_key.h
+++ b/opencensus/stats/tag_key.h
@@ -24,7 +24,8 @@
 namespace opencensus {
 namespace stats {
 
-// TagKey is a lightweight, immutable representation of a tag key.
+// TagKey is a lightweight, immutable representation of a tag key. It has a
+// trivial destructor and can be safely used as a local static variable.
 class TagKey final {
  public:
   // Registers a tag key with 'name'. Registering the same name twice produces


### PR DESCRIPTION
Inspired by concern about whether the style guide allowed our recommended function-wrapping-a-static style: https://github.com/grpc/grpc/pull/15196.