### PR TITLE
assert(false) after switch().

### DIFF
--- a/examples/grpc/BUILD
+++ b/examples/grpc/BUILD
@@ -73,7 +73,7 @@ cc_binary(
         "//opencensus/trace",
         "@com_github_grpc_grpc//:grpc++",
         "@com_github_grpc_grpc//:grpc_opencensus_plugin",
-        "@com_github_jupp0r_prometheus_cpp//:prometheus_cpp",
+        "@com_github_jupp0r_prometheus_cpp//pull",
         "@com_google_absl//absl/strings",
     ],
 )

--- a/opencensus/copts.bzl
+++ b/opencensus/copts.bzl
@@ -18,7 +18,7 @@ Flags specified here must not impact ABI. Code compiled with and without these
 opts will be linked together, and in some cases headers compiled with and
 without these options will be part of the same program.
 
-We use the same flags as absl.
+We use the same flags as absl, plus turn some warnings into errors.
 """
 
 load(
@@ -31,18 +31,16 @@ load(
     "MSVC_TEST_FLAGS",
 )
 
+WERROR = ["-Werror=return-type", "-Werror=switch"]
+
 DEFAULT_COPTS = select({
-    "//opencensus:llvm_compiler": LLVM_FLAGS,
-    # Disable "not all control paths return a value"; functions that return
-    # out of a switch on an enum cause build errors otherwise.
-    "//opencensus:windows": MSVC_FLAGS + ["/wd4715"],
-    "//conditions:default": GCC_FLAGS,
+    "//opencensus:llvm_compiler": LLVM_FLAGS + WERROR,
+    "//opencensus:windows": MSVC_FLAGS,
+    "//conditions:default": GCC_FLAGS + WERROR,
 })
 
 TEST_COPTS = DEFAULT_COPTS + select({
-    "//opencensus:llvm_compiler": LLVM_TEST_FLAGS,
-    # Disable "not all control paths return a value"; functions that return
-    # out of a switch on an enum cause build errors otherwise.
-    "//opencensus:windows": MSVC_TEST_FLAGS + ["/wd4715"],
-    "//conditions:default": GCC_TEST_FLAGS,
+    "//opencensus:llvm_compiler": LLVM_TEST_FLAGS + WERROR,
+    "//opencensus:windows": MSVC_TEST_FLAGS,
+    "//conditions:default": GCC_TEST_FLAGS + WERROR,
 })

--- a/opencensus/exporters/stats/prometheus/BUILD
+++ b/opencensus/exporters/stats/prometheus/BUILD
@@ -27,7 +27,7 @@ cc_library(
     deps = [
         ":prometheus_utils",
         "//opencensus/stats",
-        "@com_github_jupp0r_prometheus_cpp//:prometheus_cpp",
+        "@com_github_jupp0r_prometheus_cpp//core",
     ],
 )
 
@@ -41,7 +41,7 @@ cc_library(
     copts = DEFAULT_COPTS,
     deps = [
         "//opencensus/stats",
-        "@com_github_jupp0r_prometheus_cpp//:prometheus_cpp",
+        "@com_github_jupp0r_prometheus_cpp//core",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/time",
     ],
@@ -69,7 +69,7 @@ cc_binary(
     deps = [
         ":prometheus_exporter",
         "//opencensus/stats",
-        "@com_github_jupp0r_prometheus_cpp//:prometheus_cpp",
+        "@com_github_jupp0r_prometheus_cpp//pull",
         "@com_google_absl//absl/time",
     ],
 )

--- a/opencensus/exporters/stats/prometheus/internal/prometheus_utils.cc
+++ b/opencensus/exporters/stats/prometheus/internal/prometheus_utils.cc
@@ -55,6 +55,8 @@ prometheus::MetricType MetricType(opencensus::stats::Aggregation::Type type) {
     case opencensus::stats::Aggregation::Type::kDistribution:
       return prometheus::MetricType::Histogram;
   }
+  ABSL_ASSERT(false && "Bad MetricType.");
+  return prometheus::MetricType::Untyped;
 }
 
 void SetValue(double value, prometheus::MetricType type,

--- a/opencensus/exporters/stats/stackdriver/internal/stackdriver_utils.cc
+++ b/opencensus/exporters/stats/stackdriver/internal/stackdriver_utils.cc
@@ -83,6 +83,8 @@ google::api::MetricDescriptor::ValueType GetValueType(
     case opencensus::stats::Aggregation::Type::kDistribution:
       return google::api::MetricDescriptor::DISTRIBUTION;
   }
+  ABSL_ASSERT(false && "Bad descriptor type.");
+  return google::api::MetricDescriptor::DOUBLE;
 }
 
 // Overloaded function for converting ViewData value types to Points. The
@@ -197,6 +199,8 @@ std::vector<google::monitoring::v3::TimeSeries> MakeTimeSeries(
       return DataToTimeSeries(view_descriptor, data.distribution_data(),
                               base_time_series);
   }
+  ABSL_ASSERT(false && "Bad ViewData.type().");
+  return {};
 }
 
 void SetTimestamp(absl::Time time, google::protobuf::Timestamp* proto) {

--- a/opencensus/stats/internal/aggregation.cc
+++ b/opencensus/stats/internal/aggregation.cc
@@ -14,6 +14,8 @@
 
 #include "opencensus/stats/aggregation.h"
 
+#include <cassert>
+
 #include "absl/strings/str_cat.h"
 
 namespace opencensus {
@@ -21,20 +23,18 @@ namespace stats {
 
 std::string Aggregation::DebugString() const {
   switch (type_) {
-    case Type::kCount: {
+    case Type::kCount:
       return "Count";
-    }
-    case Type::kSum: {
+    case Type::kSum:
       return "Sum";
-    }
-    case Type::kDistribution: {
+    case Type::kDistribution:
       return absl::StrCat("Distribution with ",
                           bucket_boundaries_.DebugString());
-    }
-    case Type::kLastValue: {
+    case Type::kLastValue:
       return "Last Value";
-    }
   }
+  assert(false && "Invalid Aggregation type.");
+  return "BAD TYPE";
 }
 
 }  // namespace stats

--- a/opencensus/stats/internal/aggregation_window.cc
+++ b/opencensus/stats/internal/aggregation_window.cc
@@ -14,6 +14,8 @@
 
 #include "opencensus/stats/internal/aggregation_window.h"
 
+#include <cassert>
+
 #include "absl/strings/str_cat.h"
 
 namespace opencensus {
@@ -29,6 +31,8 @@ std::string AggregationWindow::DebugString() const {
       return absl::StrCat("Interval (", absl::ToDoubleSeconds(duration_),
                           "s window)");
   }
+  assert(false && "Bad AggregationWindow type.");
+  return "BAD TYPE";
 }
 
 }  // namespace stats

--- a/opencensus/stats/internal/view_data.cc
+++ b/opencensus/stats/internal/view_data.cc
@@ -41,6 +41,8 @@ ViewData::Type ViewData::type() const {
       // map.
       return Type::kDouble;
   }
+  ABSL_ASSERT(false && "Bad ViewData type.");
+  return Type::kDouble;
 }
 
 const ViewData::DataMap<double>& ViewData::double_data() const {

--- a/opencensus/stats/internal/view_data_impl.cc
+++ b/opencensus/stats/internal/view_data_impl.cc
@@ -49,6 +49,8 @@ ViewDataImpl::Type ViewDataImpl::TypeForDescriptor(
     case AggregationWindow::Type::kInterval:
       return ViewDataImpl::Type::kStatsObject;
   }
+  ABSL_ASSERT(false && "Bad ViewDataImpl type.");
+  return ViewDataImpl::Type::kDouble;
 }
 
 ViewDataImpl::ViewDataImpl(absl::Time start_time,


### PR DESCRIPTION
This stops gcc from warning about -Wreturn-type.
Make -Wreturn-type and -Wswitch into errors.
Fixes https://github.com/census-instrumentation/opencensus-cpp/issues/79