### PR TITLE
Don't depend on gRPC private header.

### DIFF
--- a/examples/grpc/hello_server.cc
+++ b/examples/grpc/hello_server.cc
@@ -37,7 +37,6 @@
 #include "opencensus/trace/span.h"
 #include "opencensus/trace/trace_config.h"
 #include "prometheus/exposer.h"
-#include "src/cpp/ext/filters/census/grpc_plugin.h"
 
 namespace {
 


### PR DESCRIPTION
GetSpanFromServerContext() comes from <grpcpp/opencensus.h> as of
https://github.com/grpc/grpc/pull/15984