### PR TITLE
Add StackdriverExporterOptions to StackdriverExporter::Register().

### DIFF
--- a/opencensus/exporters/trace/stackdriver/stackdriver_exporter.h
+++ b/opencensus/exporters/trace/stackdriver/stackdriver_exporter.h
@@ -16,15 +16,33 @@
 #define OPENCENSUS_EXPORTERS_TRACE_STACKDRIVER_STACKDRIVER_EXPORTER_H_
 
 #include "absl/strings/string_view.h"
+#include "opencensus/common/internal/grpc/status.h"
 
 namespace opencensus {
 namespace exporters {
 namespace trace {
 
+struct StackdriverExporterOptions {
+  // If true, Register() blocks until a connection is established and returns a
+  // meaningful Status object.
+  bool block_until_connected = false;
+
+  // Deadline to set on outgoing RPCs.
+  double rpc_deadline_secs = 3.0;
+
+  static StackdriverExporterOptions Default() {
+    return StackdriverExporterOptions();
+  }
+};
+
 class StackdriverExporter {
  public:
-  // Registers the exporter and sets the project ID.
-  static void Register(absl::string_view project_id);
+  // Registers the exporter and sets the project ID. Returns OK and initializes
+  // in the background, unless opts.block_until_connected is true, in which case
+  // it blocks and returns a meaningful Status.
+  static grpc::Status Register(absl::string_view project_id,
+                               const StackdriverExporterOptions& opts =
+                                   StackdriverExporterOptions::Default());
 
  private:
   StackdriverExporter() = delete;


### PR DESCRIPTION
Use this to configure RPC deadlines and whether to block until
the exporter is connected.

Also change Register() to return a grpc::Status.