### PR TITLE
Simplify stats::StackdriverExporter.

### DIFF
--- a/examples/grpc/BUILD
+++ b/examples/grpc/BUILD
@@ -55,6 +55,7 @@ cc_binary(
         "@com_github_grpc_grpc//:grpc++",
         "@com_github_grpc_grpc//:grpc_opencensus_plugin",
         "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/time",
     ],
 )
 

--- a/examples/grpc/hello_client.cc
+++ b/examples/grpc/hello_client.cc
@@ -20,6 +20,7 @@
 #include <grpcpp/grpcpp.h>
 #include <grpcpp/opencensus.h>
 
+#include "absl/time/clock.h"
 #include "examples/grpc/hello.grpc.pb.h"
 #include "examples/grpc/hello.pb.h"
 #include "examples/grpc/stackdriver.h"

--- a/opencensus/exporters/stats/stackdriver/README.md
+++ b/opencensus/exporters/stats/stackdriver/README.md
@@ -35,7 +35,7 @@ that key.
 
 Please refer to the [Stats access controls](https://cloud.google.com/monitoring/access-control)
 and [Trace access controls](https://cloud.google.com/trace/docs/iam)
-documentation for configuring roles.
+documentation for configuring roles. The "Monitoring Editor" role is required.
 
 ### Register the exporter
 

--- a/opencensus/exporters/stats/stackdriver/stackdriver_exporter.h
+++ b/opencensus/exporters/stats/stackdriver/stackdriver_exporter.h
@@ -16,37 +16,23 @@
 #define OPENCENSUS_EXPORTERS_STATS_STACKDRIVER_STACKDRIVER_EXPORTER_H_
 
 #include "absl/strings/string_view.h"
-#include "opencensus/stats/stats.h"
 
 namespace opencensus {
 namespace exporters {
 namespace stats {
 
 // Exports stats for registered views (see opencensus/stats/stats_exporter.h) to
-// Stackdriver.
-// StackdriverExporter is thread-safe.
-class StackdriverExporter : public ::opencensus::stats::StatsExporter::Handler {
+// Stackdriver. StackdriverExporter is thread-safe.
+class StackdriverExporter {
  public:
-  // Registers the exporter and sets the project ID and task value. The
-  // following are required to communicate with stackdriver: a valid project ID,
-  // a valid authentication key which has been generated for that project (with
-  // the "Monitoring Editor" role), and the server security credentials. An
-  // authentication key can be generated for your project in the gcp/stackdriver
-  // settings for your account. Grpc will look for the key using the path
-  // defined by GOOGLE_APPLICATION_CREDENTIALS environment variable (export
-  // GOOGLE_APPLICATION_CREDENTIALS=<path_to_key>). The server security
-  // credentials located in <grpc_path>/etc/roots.pem needs to be copied to
-  // /usr/share/grpc/roots.pem
-  // project_id should be the exact id of the project, as in the GCP console,
-  // with no prefix--e.g. "sample-project-id". opencensus_task is used to
-  // uniquely identify the task in Stackdriver. The recommended format is
-  // "{LANGUAGE}-{PID}@{HOSTNAME}"; if {PID} is not available a random number
-  // may be used.
+  // Registers the exporter. By default, immediately returns OK and initializes
+  // in the background, unless opts.block_until_connected is true, in which case
+  // it blocks and returns a meaningful Status.
   static void Register(absl::string_view project_id,
                        absl::string_view opencensus_task);
 
  private:
-  class Handler;
+  StackdriverExporter() = delete;
 };
 
 }  // namespace stats

--- a/opencensus/exporters/stats/stackdriver/stackdriver_exporter.h
+++ b/opencensus/exporters/stats/stackdriver/stackdriver_exporter.h
@@ -25,9 +25,12 @@ namespace stats {
 // Stackdriver. StackdriverExporter is thread-safe.
 class StackdriverExporter {
  public:
-  // Registers the exporter. By default, immediately returns OK and initializes
-  // in the background, unless opts.block_until_connected is true, in which case
-  // it blocks and returns a meaningful Status.
+  // Registers the exporter and sets the project ID and task value. project_id
+  // should be the exact id of the project, as in the GCP console, with no
+  // prefix--e.g. "sample-project-id". opencensus_task is used to uniquely
+  // identify the task in Stackdriver. The recommended format is
+  // "{LANGUAGE}-{PID}@{HOSTNAME}"; if {PID} is not available a random number
+  // may be used.
   static void Register(absl::string_view project_id,
                        absl::string_view opencensus_task);
 


### PR DESCRIPTION
This makes it look more like trace::StackdriverExporter, and reduces
includes.