### PR TITLE
Add operator!= to SpanContext.

### DIFF
--- a/opencensus/trace/internal/span_context.cc
+++ b/opencensus/trace/internal/span_context.cc
@@ -23,6 +23,10 @@ bool SpanContext::operator==(const SpanContext& that) const {
   return trace_id_ == that.trace_id() && span_id_ == that.span_id();
 }
 
+bool SpanContext::operator!=(const SpanContext& that) const {
+  return !(*this == that);
+}
+
 bool SpanContext::IsValid() const {
   return trace_id_.IsValid() && span_id_.IsValid();
 }

--- a/opencensus/trace/internal/span_context_test.cc
+++ b/opencensus/trace/internal/span_context_test.cc
@@ -47,6 +47,7 @@ TEST(SpanContextTest, Equality) {
   SpanContext ctx4{TraceId(trace_id), SpanId(span_id), TraceOptions(opts)};
 
   EXPECT_EQ(ctx1, ctx1);
+  EXPECT_NE(ctx1, ctx2);
   EXPECT_EQ(ctx1, ctx3) << "Same contents, different objects.";
   EXPECT_EQ(ctx1, ctx4) << "Comparison ignores options.";
   EXPECT_FALSE(ctx1 == ctx2);

--- a/opencensus/trace/span_context.h
+++ b/opencensus/trace/span_context.h
@@ -56,6 +56,10 @@ class SpanContext final {
   // not TraceOptions!
   bool operator==(const SpanContext& that) const;
 
+  // Compares two SpanContexts for inequality. Only compares TraceId and SpanId,
+  // not TraceOptions!
+  bool operator!=(const SpanContext& that) const;
+
   // Returns true if SpanId and TraceId are valid.
   bool IsValid() const;
 


### PR DESCRIPTION
Motivated by EXPECT_NE() in unit tests.