### PR TITLE
Windows: remove --output_user_root workaround.

### DIFF
--- a/tools/appveyor/build.bat
+++ b/tools/appveyor/build.bat
@@ -21,11 +21,9 @@ FOR /F usebackq %%T IN (`bazel query "kind(rule, //...)" ^| FINDSTR /C:"\:_" /V`
     SET BUILDABLES=!BUILDABLES! %%T
 )
 
-REM TODO: Remove --output_user_root after https://github.com/bazelbuild/bazel/issues/4149 is fixed.
 REM TODO: enable the full build when errors are resolved.
-REM bazel --output_user_root=c:/t/ build //opencensus/trace //opencensus/stats
 bazel build //opencensus/trace //opencensus/stats
-REM bazel --output_user_root=c:/t/ build %BUILDABLES%
+REM bazel build %BUILDABLES%
 
 IF %ERRORLEVEL% NEQ 0 EXIT /b %ERRORLEVEL%
 EXIT /b 0

--- a/tools/appveyor/build.bat
+++ b/tools/appveyor/build.bat
@@ -23,7 +23,8 @@ FOR /F usebackq %%T IN (`bazel query "kind(rule, //...)" ^| FINDSTR /C:"\:_" /V`
 
 REM TODO: Remove --output_user_root after https://github.com/bazelbuild/bazel/issues/4149 is fixed.
 REM TODO: enable the full build when errors are resolved.
-bazel --output_user_root=c:/t/ build //opencensus/trace //opencensus/stats
+REM bazel --output_user_root=c:/t/ build //opencensus/trace //opencensus/stats
+bazel build //opencensus/trace //opencensus/stats
 REM bazel --output_user_root=c:/t/ build %BUILDABLES%
 
 IF %ERRORLEVEL% NEQ 0 EXIT /b %ERRORLEVEL%

--- a/tools/appveyor/install.bat
+++ b/tools/appveyor/install.bat
@@ -19,7 +19,7 @@ IF NOT EXIST %INSTALL_CACHE% (MKDIR %INSTALL_CACHE%)
 
 REM Download bazel into install cache, which is on the path.
 IF NOT EXIST %INSTALL_CACHE%\bazel.exe (
-  appveyor DownloadFile https://github.com/bazelbuild/bazel/releases/download/0.17.1/bazel-0.17.1-without-jdk-windows-x86_64.exe -FileName %INSTALL_CACHE%\bazel.exe
+  appveyor DownloadFile https://github.com/bazelbuild/bazel/releases/download/0.17.1/bazel-0.17.1-windows-x86_64.exe -FileName %INSTALL_CACHE%\bazel.exe
 )
 
 REM Temporary directory for bazel.

--- a/tools/appveyor/install.bat
+++ b/tools/appveyor/install.bat
@@ -19,7 +19,7 @@ IF NOT EXIST %INSTALL_CACHE% (MKDIR %INSTALL_CACHE%)
 
 REM Download bazel into install cache, which is on the path.
 IF NOT EXIST %INSTALL_CACHE%\bazel.exe (
-  appveyor DownloadFile https://github.com/bazelbuild/bazel/releases/download/0.11.1/bazel-0.11.1-without-jdk-windows-x86_64.exe -FileName %INSTALL_CACHE%\bazel.exe
+  appveyor DownloadFile https://github.com/bazelbuild/bazel/releases/download/0.17.1/bazel-0.17.1-without-jdk-windows-x86_64.exe -FileName %INSTALL_CACHE%\bazel.exe
 )
 
 REM Temporary directory for bazel.

--- a/tools/appveyor/test.bat
+++ b/tools/appveyor/test.bat
@@ -21,9 +21,8 @@ FOR /F usebackq %%T IN (`bazel query "kind(test, //...)  except attr('tags', 'ma
     SET TESTS=!TESTS! %%T
 )
 
-REM TODO: Remove --output_user_root after https://github.com/bazelbuild/bazel/issues/4149 is fixed.
 echo TODO: Make all tests pass on Windows.
-REM bazel --output_user_root=c:/t/ test --test_output=errors %TESTS%
+REM bazel test --test_output=errors %TESTS%
 
 IF %ERRORLEVEL% NEQ 0 EXIT /b %ERRORLEVEL%
 EXIT /b 0


### PR DESCRIPTION
It's no longer required, new versions of bazel fix the problem of long paths.