### PR TITLE
Check that WithContext is constructed and destructed on the same thread.

### DIFF
--- a/opencensus/context/with_context.h
+++ b/opencensus/context/with_context.h
@@ -40,6 +40,9 @@ class WithContext {
   WithContext& operator=(WithContext&&) = delete;
 
   Context swapped_context_;
+#ifndef NDEBUG
+  const Context* original_context_;
+#endif
 };
 
 }  // namespace context


### PR DESCRIPTION
This only happens in debug mode (!NDEBUG).
Add a death test for it.