### PR TITLE
Make context_test expect the right tags and span.

### DIFF
--- a/opencensus/context/BUILD
+++ b/opencensus/context/BUILD
@@ -49,6 +49,10 @@ cc_test(
     copts = TEST_COPTS,
     deps = [
         ":context",
+        "//opencensus/tags:context_util",
+        "//opencensus/tags:with_tag_map",
+        "//opencensus/trace:context_util",
+        "//opencensus/trace:with_span",
         "@com_google_googletest//:gtest_main",
     ],
 )


### PR DESCRIPTION
Especially when Wrap()ing functions.
This is easier now that we have the With* classes and utilities.