### PR TITLE
prometheus/metric.h was deleted as dead code.

### DIFF
--- a/opencensus/exporters/stats/prometheus/internal/prometheus_utils.cc
+++ b/opencensus/exporters/stats/prometheus/internal/prometheus_utils.cc
@@ -26,7 +26,6 @@
 #include "absl/strings/string_view.h"
 #include "absl/time/time.h"
 #include "opencensus/stats/stats.h"
-#include "prometheus/metric.h"
 #include "prometheus/metric_type.h"
 
 namespace opencensus {


### PR DESCRIPTION
In https://github.com/jupp0r/prometheus-cpp/pull/169