### PR TITLE
Add absl deps that stats headers use.

### DIFF
--- a/opencensus/stats/BUILD
+++ b/opencensus/stats/BUILD
@@ -34,6 +34,8 @@ cc_library(
     deps = [
         ":core",
         ":recording",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/time",
     ],
 )
 


### PR DESCRIPTION
Previously the build picked these up transitively. It's better
to be explicit.