### PR TITLE
Change the Stackdriver exporters' Register() to return Status.

### DIFF
--- a/opencensus/exporters/stats/stackdriver/internal/stackdriver_exporter.cc
+++ b/opencensus/exporters/stats/stackdriver/internal/stackdriver_exporter.cc
@@ -163,9 +163,11 @@ bool Handler::MaybeRegisterView(
 }  // namespace
 
 // static
-void StackdriverExporter::Register(const StackdriverOptions& opts) {
+grpc::Status StackdriverExporter::Register(const StackdriverOptions& opts) {
   opencensus::stats::StatsExporter::RegisterPushHandler(
       absl::WrapUnique(new Handler(opts)));
+  // TODO: Propagate errors to caller. For now we just return OK.
+  return grpc::Status::OK;
 }
 
 // static, DEPRECATED

--- a/opencensus/exporters/stats/stackdriver/stackdriver_exporter.h
+++ b/opencensus/exporters/stats/stackdriver/stackdriver_exporter.h
@@ -17,6 +17,7 @@
 
 #include <string>
 
+#include <grpcpp/support/status.h>
 #include "absl/base/macros.h"
 #include "absl/strings/string_view.h"
 #include "absl/time/time.h"
@@ -42,8 +43,9 @@ struct StackdriverOptions {
 // Stackdriver. StackdriverExporter is thread-safe.
 class StackdriverExporter {
  public:
-  // Registers the exporter.
-  static void Register(const StackdriverOptions& opts);
+  // Registers the exporter and returns OK on success or another Status code
+  // otherwise.
+  static grpc::Status Register(const StackdriverOptions& opts);
 
   // TODO: Retire this:
   ABSL_DEPRECATED(

--- a/opencensus/exporters/trace/stackdriver/internal/stackdriver_exporter.cc
+++ b/opencensus/exporters/trace/stackdriver/internal/stackdriver_exporter.cc
@@ -270,11 +270,13 @@ void Handler::Export(
 }  // namespace
 
 // static
-void StackdriverExporter::Register(const StackdriverOptions& opts) {
+grpc::Status StackdriverExporter::Register(const StackdriverOptions& opts) {
   auto creds = grpc::GoogleDefaultCredentials();
   auto channel = ::grpc::CreateChannel(kGoogleStackdriverTraceAddress, creds);
   ::opencensus::trace::exporter::SpanExporter::RegisterHandler(
       absl::make_unique<Handler>(opts, channel));
+  // TODO: Propagate errors to caller. For now we just return OK.
+  return grpc::Status::OK;
 }
 
 // static, DEPRECATED

--- a/opencensus/exporters/trace/stackdriver/stackdriver_exporter.h
+++ b/opencensus/exporters/trace/stackdriver/stackdriver_exporter.h
@@ -17,6 +17,7 @@
 
 #include <string>
 
+#include <grpcpp/support/status.h>
 #include "absl/base/macros.h"
 #include "absl/strings/string_view.h"
 #include "absl/time/time.h"
@@ -35,8 +36,9 @@ struct StackdriverOptions {
 
 class StackdriverExporter {
  public:
-  // Registers the exporter.
-  static void Register(const StackdriverOptions& opts);
+  // Registers the exporter and returns OK on success or another Status code
+  // otherwise.
+  static grpc::Status Register(const StackdriverOptions& opts);
 
   // TODO: Retire this:
   ABSL_DEPRECATED(


### PR DESCRIPTION
Make this non-breaking change to the API now, so we can use it
to implement https://github.com/census-instrumentation/opencensus-cpp/issues/175
later.