### PR TITLE
Cleanups for BUILD files.

### DIFF
--- a/opencensus/common/internal/BUILD
+++ b/opencensus/common/internal/BUILD
@@ -44,7 +44,6 @@ cc_library(
     copts = DEFAULT_COPTS,
     deps = [
         "@com_google_absl//absl/base:core_headers",
-        "@com_google_absl//absl/memory",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/time",
         "@com_google_absl//absl/types:span",

--- a/opencensus/common/internal/BUILD
+++ b/opencensus/common/internal/BUILD
@@ -32,6 +32,7 @@ cc_library(
     hdrs = ["random.h"],
     copts = DEFAULT_COPTS,
     deps = [
+        "@com_google_absl//absl/base:core_headers",
         "@com_google_absl//absl/synchronization",
         "@com_google_absl//absl/time",
     ],

--- a/opencensus/context/BUILD
+++ b/opencensus/context/BUILD
@@ -49,8 +49,10 @@ cc_test(
     copts = TEST_COPTS,
     deps = [
         ":context",
+        "//opencensus/tags",
         "//opencensus/tags:context_util",
         "//opencensus/tags:with_tag_map",
+        "//opencensus/trace",
         "//opencensus/trace:context_util",
         "//opencensus/trace:with_span",
         "@com_google_googletest//:gtest_main",

--- a/opencensus/exporters/stats/stdout/BUILD
+++ b/opencensus/exporters/stats/stdout/BUILD
@@ -40,7 +40,6 @@ cc_test(
         ":stdout_exporter",
         "//opencensus/stats",
         "//opencensus/stats:test_utils",
-        "@com_google_absl//absl/time",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/opencensus/exporters/trace/stackdriver/BUILD
+++ b/opencensus/exporters/trace/stackdriver/BUILD
@@ -33,8 +33,9 @@ cc_library(
         "//opencensus/common/internal/grpc:status",
         "//opencensus/trace",
         "@com_github_grpc_grpc//:grpc++",
-        "@com_google_absl//absl/base",
+        "@com_google_absl//absl/base:core_headers",
         "@com_google_absl//absl/memory",
         "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/time",
     ],
 )

--- a/opencensus/stats/BUILD
+++ b/opencensus/stats/BUILD
@@ -107,7 +107,6 @@ cc_library(
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/synchronization",
         "@com_google_absl//absl/time",
-        "@com_google_absl//absl/types:optional",
         "@com_google_absl//absl/types:span",
     ],
 )
@@ -121,8 +120,6 @@ cc_library(
         ":core",
         "//opencensus/tags",
         "//opencensus/tags:context_util",
-        "@com_google_absl//absl/strings",
-        "@com_google_absl//absl/time",
     ],
 )
 
@@ -191,7 +188,6 @@ cc_test(
     copts = TEST_COPTS,
     deps = [
         ":core",
-        ":recording",
         "@com_google_absl//absl/memory",
         "@com_google_absl//absl/time",
         "@com_google_googletest//:gtest_main",

--- a/opencensus/trace/BUILD
+++ b/opencensus/trace/BUILD
@@ -84,7 +84,6 @@ cc_library(
         "//opencensus/common/internal:random_lib",
         "@com_google_absl//absl/base:core_headers",
         "@com_google_absl//absl/base:endian",
-        "@com_google_absl//absl/memory",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/synchronization",
         "@com_google_absl//absl/time",
@@ -125,7 +124,6 @@ cc_test(
     copts = TEST_COPTS,
     deps = [
         ":trace",
-        "@com_google_absl//absl/strings",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -181,8 +179,6 @@ cc_test(
     copts = TEST_COPTS,
     deps = [
         ":trace",
-        "@com_google_absl//absl/memory",
-        "@com_google_absl//absl/synchronization",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -195,7 +191,6 @@ cc_test(
         ":trace",
         "@com_google_absl//absl/base:core_headers",
         "@com_google_absl//absl/memory",
-        "@com_google_absl//absl/synchronization",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -207,7 +202,6 @@ cc_test(
     deps = [
         ":trace",
         "@com_google_absl//absl/strings",
-        "@com_google_absl//absl/synchronization",
         "@com_google_absl//absl/time",
         "@com_google_googletest//:gtest_main",
     ],
@@ -252,8 +246,6 @@ cc_test(
     copts = TEST_COPTS,
     deps = [
         ":trace",
-        "@com_google_absl//absl/strings",
-        "@com_google_absl//absl/types:span",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -265,7 +257,6 @@ cc_test(
     deps = [
         ":trace",
         "@com_google_absl//absl/memory",
-        "@com_google_absl//absl/strings",
         "@com_google_absl//absl/synchronization",
         "@com_google_absl//absl/time",
         "@com_google_googletest//:gtest_main",
@@ -278,7 +269,6 @@ cc_test(
     copts = TEST_COPTS,
     deps = [
         ":trace",
-        "@com_google_absl//absl/strings",
         "@com_google_googletest//:gtest_main",
     ],
 )


### PR DESCRIPTION
- Add dependencies we were previously picking up transitively.
- Remove unnecessary dependencies.