### PR TITLE
Unbreak caching on Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,6 @@ before_install:
   - ./bazel-0.19.2-installer-${BAZEL_OS}-x86_64.sh --user
   - echo "build --disk_cache=$HOME/bazel-cache" > ~/.bazelrc
   - echo "build --experimental_strict_action_env" >> ~/.bazelrc
-  - echo "build --no-such-flag" >> ~/.bazelrc
 
 script:
   # Limit the amount of progress output. We can't use --noshow_progress because

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ before_install:
   - ./bazel-0.17.1-installer-${BAZEL_OS}-x86_64.sh --user
   - echo "build --disk_cache=$HOME/bazel-cache" > ~/.bazelrc
   - echo "build --experimental_strict_action_env" >> ~/.bazelrc
+  - echo "build --no-such-flag" >> ~/.bazelrc
 
 script:
   # Limit the amount of progress output. We can't use --noshow_progress because

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,9 +29,9 @@ before_install:
       fi;
       tools/format.sh;
     fi
-  - wget https://github.com/bazelbuild/bazel/releases/download/0.17.1/bazel-0.17.1-installer-${BAZEL_OS}-x86_64.sh
-  - chmod +x bazel-0.17.1-installer-${BAZEL_OS}-x86_64.sh
-  - ./bazel-0.17.1-installer-${BAZEL_OS}-x86_64.sh --user
+  - wget https://github.com/bazelbuild/bazel/releases/download/0.19.2/bazel-0.19.2-installer-${BAZEL_OS}-x86_64.sh
+  - chmod +x bazel-0.19.2-installer-${BAZEL_OS}-x86_64.sh
+  - ./bazel-0.19.2-installer-${BAZEL_OS}-x86_64.sh --user
   - echo "build --disk_cache=$HOME/bazel-cache" > ~/.bazelrc
   - echo "build --experimental_strict_action_env" >> ~/.bazelrc
   - echo "build --no-such-flag" >> ~/.bazelrc

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,5 +42,5 @@ script:
   - bazel test $BAZEL_OPTIONS --experimental_ui_actions_shown=1 -k $(bazel query "kind(test, //...) except attr('tags', 'manual|noci', //...)" | grep -v :_)
 
 before_cache:
-  # Before uploading cache.
+  # Before uploading cache, report its size.
   - du -sk $HOME/bazel-cache

--- a/tools/appveyor/install.bat
+++ b/tools/appveyor/install.bat
@@ -19,7 +19,7 @@ IF NOT EXIST %INSTALL_CACHE% (MKDIR %INSTALL_CACHE%)
 
 REM Download bazel into install cache, which is on the path.
 IF NOT EXIST %INSTALL_CACHE%\bazel.exe (
-  appveyor DownloadFile https://github.com/bazelbuild/bazel/releases/download/0.17.1/bazel-0.17.1-windows-x86_64.exe -FileName %INSTALL_CACHE%\bazel.exe
+  appveyor DownloadFile https://github.com/bazelbuild/bazel/releases/download/0.19.2/bazel-0.19.2-windows-x86_64.exe -FileName %INSTALL_CACHE%\bazel.exe
 )
 
 REM Temporary directory for bazel.


### PR DESCRIPTION
bazel 0.17.1 ignores HOME/.bazelrc (where we configure caching) if WORKSPACE/.bazelrc is present (which I populated in https://github.com/census-instrumentation/opencensus-cpp/commit/877550f3d72ef31aad662b1baf9d070fc22ce1b9 and broke caching).

Upgrade to bazel 0.19.2 which doesn't have this problem.