### PR TITLE
Build fix: switch to new http_archive rule.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,9 +29,9 @@ before_install:
       fi;
       tools/format.sh;
     fi
-  - wget https://github.com/bazelbuild/bazel/releases/download/0.19.2/bazel-0.19.2-installer-${BAZEL_OS}-x86_64.sh
-  - chmod +x bazel-0.19.2-installer-${BAZEL_OS}-x86_64.sh
-  - ./bazel-0.19.2-installer-${BAZEL_OS}-x86_64.sh --user
+  - wget https://github.com/bazelbuild/bazel/releases/download/0.20.0/bazel-0.20.0-installer-${BAZEL_OS}-x86_64.sh
+  - chmod +x bazel-0.20.0-installer-${BAZEL_OS}-x86_64.sh
+  - ./bazel-0.20.0-installer-${BAZEL_OS}-x86_64.sh --user
   - echo "build --disk_cache=$HOME/bazel-cache" > ~/.bazelrc
   - echo "build --experimental_strict_action_env" >> ~/.bazelrc
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -61,6 +61,7 @@ bind(
     actual = "@com_github_grpc_grpc//:grpc_cpp_plugin",
 )
 
+# Used by prometheus-cpp.
 local_repository(
     name = "net_zlib_zlib",
     path = "tools/zlib"

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -14,6 +14,8 @@
 
 workspace(name = "io_opencensus_cpp")
 
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
 # We depend on Abseil.
 http_archive(
     name = "com_google_absl",
@@ -59,10 +61,15 @@ bind(
     actual = "@com_github_grpc_grpc//:grpc_cpp_plugin",
 )
 
+local_repository(
+    name = "net_zlib_zlib",
+    path = "tools/zlib"
+)
+
 # Prometheus client library - used by Prometheus exporter.
 http_archive(
     name = "com_github_jupp0r_prometheus_cpp",
-    repo_mapping = {"@net_zlib_zlib": "@com_github_madler_zlib"},
+    #repo_mapping = {"@net_zlib_zlib": "@com_github_madler_zlib"},
     strip_prefix = "prometheus-cpp-master",
     urls = ["https://github.com/jupp0r/prometheus-cpp/archive/master.zip"],
 )
@@ -73,7 +80,7 @@ load("@com_github_jupp0r_prometheus_cpp//:repositories.bzl", "load_civetweb")
 load_civetweb()
 
 # Curl library - used by zipkin exporter.
-new_http_archive(
+http_archive(
     name = "com_github_curl",
     build_file_content =
         """
@@ -114,7 +121,7 @@ cc_library(
 )
 
 # Rapidjson library - used by zipkin exporter.
-new_http_archive(
+http_archive(
     name = "com_github_rapidjson",
     build_file_content =
         """

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -69,7 +69,6 @@ local_repository(
 # Prometheus client library - used by Prometheus exporter.
 http_archive(
     name = "com_github_jupp0r_prometheus_cpp",
-    #repo_mapping = {"@net_zlib_zlib": "@com_github_madler_zlib"},
     strip_prefix = "prometheus-cpp-master",
     urls = ["https://github.com/jupp0r/prometheus-cpp/archive/master.zip"],
 )

--- a/tools/appveyor/install.bat
+++ b/tools/appveyor/install.bat
@@ -19,9 +19,5 @@ IF NOT EXIST %INSTALL_CACHE% (MKDIR %INSTALL_CACHE%)
 
 REM Download bazel into install cache, which is on the path.
 IF NOT EXIST %INSTALL_CACHE%\bazel.exe (
-  appveyor DownloadFile https://github.com/bazelbuild/bazel/releases/download/0.19.2/bazel-0.19.2-windows-x86_64.exe -FileName %INSTALL_CACHE%\bazel.exe
+  appveyor DownloadFile https://github.com/bazelbuild/bazel/releases/download/0.20.0/bazel-0.20.0-windows-x86_64.exe -FileName %INSTALL_CACHE%\bazel.exe
 )
-
-REM Temporary directory for bazel.
-REM TODO: Remove this after https://github.com/bazelbuild/bazel/issues/4149 is fixed.
-IF NOT EXIST C:\T (MKDIR C:\T)

--- a/tools/zlib/BUILD
+++ b/tools/zlib/BUILD
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# @com_github_madler_zlib comes from grpc_deps in the outer workspace.
+
 cc_library(
     name = "z",
     deps = ["@com_github_madler_zlib//:z"],

--- a/tools/zlib/BUILD
+++ b/tools/zlib/BUILD
@@ -1,0 +1,19 @@
+# Copyright 2018, OpenCensus Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cc_library(
+    name = "z",
+    deps = ["@com_github_madler_zlib//:z"],
+    visibility = ["//visibility:public"],
+)

--- a/tools/zlib/README.md
+++ b/tools/zlib/README.md
@@ -1,0 +1,7 @@
+`prometheus-cpp` imports `zlib` as `@net_zlib_zlib`.
+
+`grpc` imports `zlib` as `@com_github_madler_zlib`.
+
+We use this directory to join the diamond by creating a
+`@net_zlib_zlib` external repository that just maps to
+`@com_github_madler_zlib`.

--- a/tools/zlib/WORKSPACE
+++ b/tools/zlib/WORKSPACE
@@ -1,0 +1,15 @@
+# Copyright 2018, OpenCensus Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+workspace(name = "net_zlib_zlib")


### PR DESCRIPTION
* Upgrade bazel to 0.20.0 where the old rule is gone.

* `repo_mapping` is gone, join the diamond using a `local_repository`
  in `tools/zlib/`.

* appveyor: remove the Windows temporary directory we stopped using
  in #198.