### PR TITLE
Travis: add gcc and CMake.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,46 +1,35 @@
 language: cpp
+compiler: clang
+
 matrix:
   include:
     - os: linux
       dist: trusty
       sudo: false
+      name: "check format"
+      script: tools/travis/check_format.sh
+    - os: linux
+      dist: trusty
+      sudo: false
       env: BAZEL_OS=linux
+      script: tools/travis/build_bazel.sh
+    - os: linux
+      dist: trusty
+      sudo: false
+      compiler: gcc
+      env: BAZEL_OS=linux
+      script: tools/travis/build_bazel.sh
+    - os: linux
+      dist: trusty
+      sudo: false
+      env: CMAKE_OS=linux
+      script: tools/travis/build_cmake.sh
     - os: osx
       env: BAZEL_OS=darwin
-
-compiler: clang
-
-# - Limit memory.
-# - Enable thread safety analysis (only works with clang).
-env: BAZEL_OPTIONS="--local_resources=4096,2,1.0 --copt=-Werror=thread-safety"
+      script: tools/travis/build_bazel.sh
 
 cache:
   directories:
+    - $HOME/.ccache
     - $HOME/bazel-cache
     - $HOME/gopath/bin
-
-before_install:
-  # Install buildifier if it's not present. It needs at least go 1.8.
-  # Skip format on OS X: it doesn't have clang-format by default, and has a different sed.
-  - if \[ "$TRAVIS_OS_NAME" == "linux" \]; then
-      if ! which buildifier >/dev/null; then
-        eval "$(gimme 1.11)";
-        go get -v github.com/bazelbuild/buildtools/buildifier;
-      fi;
-      tools/format.sh;
-    fi
-  - wget https://github.com/bazelbuild/bazel/releases/download/0.20.0/bazel-0.20.0-installer-${BAZEL_OS}-x86_64.sh
-  - chmod +x bazel-0.20.0-installer-${BAZEL_OS}-x86_64.sh
-  - ./bazel-0.20.0-installer-${BAZEL_OS}-x86_64.sh --user
-  - echo "build --disk_cache=$HOME/bazel-cache" > ~/.bazelrc
-  - echo "build --experimental_strict_action_env" >> ~/.bazelrc
-
-script:
-  # Limit the amount of progress output. We can't use --noshow_progress because
-  # Travis terminates the build after 10 mins without output.
-  - bazel build $BAZEL_OPTIONS --experimental_ui_actions_shown=1 -k $(bazel query "kind(rule, //...)" | grep -v :_)
-  - bazel test $BAZEL_OPTIONS --experimental_ui_actions_shown=1 -k $(bazel query "kind(test, //...) except attr('tags', 'manual|noci', //...)" | grep -v :_)
-
-before_cache:
-  # Before uploading cache, report its size.
-  - du -sk $HOME/bazel-cache

--- a/tools/travis/build_bazel.sh
+++ b/tools/travis/build_bazel.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Copyright 2018, OpenCensus Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+set -e
+set -x
+
+# Limit memory.
+export BAZEL_OPTIONS="--local_resources=4096,2,1.0"
+
+# Limit the amount of progress output. We can't use --noshow_progress because
+# Travis terminates the build after 10 mins without output.
+export BAZEL_OPTIONS="$BAZEL_OPTIONS --experimental_ui_actions_shown=1"
+
+# Enable thread safety analysis (only works with clang).
+if [[ "$TRAVIS_COMPILER" = "clang" ]]; then
+  export BAZEL_OPTIONS="$BAZEL_OPTIONS --copt=-Werror=thread-safety"
+fi
+
+wget https://github.com/bazelbuild/bazel/releases/download/0.20.0/bazel-0.20.0-installer-${BAZEL_OS}-x86_64.sh
+chmod +x bazel-0.20.0-installer-${BAZEL_OS}-x86_64.sh
+./bazel-0.20.0-installer-${BAZEL_OS}-x86_64.sh --user
+echo "build --disk_cache=$HOME/bazel-cache" > ~/.bazelrc
+echo "build --experimental_strict_action_env" >> ~/.bazelrc
+du -sk $HOME/bazel-cache || true
+
+bazel build $BAZEL_OPTIONS --experimental_ui_actions_shown=1 -k $(bazel query "kind(rule, //...)" | grep -v :_)
+bazel test $BAZEL_OPTIONS --experimental_ui_actions_shown=1 -k $(bazel query "kind(test, //...) except attr('tags', 'manual|noci', //...)" | grep -v :_)
+
+du -sk $HOME/bazel-cache || true

--- a/tools/travis/build_bazel.sh
+++ b/tools/travis/build_bazel.sh
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 set -e
 set -x
 

--- a/tools/travis/build_cmake.sh
+++ b/tools/travis/build_cmake.sh
@@ -12,9 +12,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 set -e
 set -x
+
 ccache -s
 ccache -z
 cmake -H. -B.build

--- a/tools/travis/build_cmake.sh
+++ b/tools/travis/build_cmake.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Copyright 2018, OpenCensus Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+set -e
+set -x
+ccache -s
+ccache -z
+cmake -H. -B.build
+cmake --build .build
+(cd .build && ctest --output-on-failure)
+ccache -s

--- a/tools/travis/check_format.sh
+++ b/tools/travis/check_format.sh
@@ -14,6 +14,7 @@
 # limitations under the License.
 set -e
 set -x
+
 # Install buildifier if it's not present. It needs at least go 1.8.
 if ! which buildifier >/dev/null; then
   eval "$(gimme 1.11)"

--- a/tools/travis/check_format.sh
+++ b/tools/travis/check_format.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Copyright 2018, OpenCensus Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+set -e
+set -x
+# Install buildifier if it's not present. It needs at least go 1.8.
+if ! which buildifier >/dev/null; then
+  eval "$(gimme 1.11)"
+  go get -v github.com/bazelbuild/buildtools/buildifier
+fi
+# Install cmake-format.
+pip install --user cmake_format
+# Check format.
+tools/format.sh


### PR DESCRIPTION
* Move scripts from .travis.yaml to tools/travis/*.sh.
* Run format.sh first, and separately from build tests.
  * Run cmake_format on Travis.
* Build and test with bazel + gcc (previously only clang).
* Build and test with CMake.