### PR TITLE
:context_util_test depends on :span_context.

### DIFF
--- a/opencensus/trace/BUILD
+++ b/opencensus/trace/BUILD
@@ -199,6 +199,7 @@ cc_test(
     copts = TEST_COPTS,
     deps = [
         ":context_util",
+        ":span_context",
         ":trace",
         ":with_span",
         "//opencensus/context",


### PR DESCRIPTION
Previously it was picking it up transitively.