### PR TITLE
Don't collect spans for export until an exporter has been registered.

### DIFF
--- a/opencensus/trace/internal/span_exporter_impl.h
+++ b/opencensus/trace/internal/span_exporter_impl.h
@@ -88,6 +88,8 @@ class SpanExporterImpl {
   std::vector<std::unique_ptr<SpanExporter::Handler>> handlers_
       GUARDED_BY(handler_mu_);
   bool thread_started_ GUARDED_BY(handler_mu_) = false;
+  // Don't collect spans until an exporter has been registered.
+  bool collect_spans_ GUARDED_BY(span_mu_) = false;
   std::thread t_ GUARDED_BY(handler_mu_);
 };
 


### PR DESCRIPTION
Otherwise sampled spans will pile up in memory.