### PR TITLE
Add NOMINMAX definitions when compiling with MSVC

### DIFF
--- a/opencensus/common/internal/CMakeLists.txt
+++ b/opencensus/common/internal/CMakeLists.txt
@@ -24,7 +24,7 @@ opencensus_lib(common_random
 
 opencensus_lib(common_stats_object DEPS absl::time)
 
-# Defines NOMINMAX when compiling with MSVC to fix build errors
+# Define NOMINMAX to fix build errors when compiling with MSVC.
 target_compile_definitions(opencensus_common_stats_object INTERFACE $<$<CXX_COMPILER_ID:MSVC>:NOMINMAX>)
 
 opencensus_lib(common_string_vector_hash)

--- a/opencensus/common/internal/CMakeLists.txt
+++ b/opencensus/common/internal/CMakeLists.txt
@@ -25,7 +25,8 @@ opencensus_lib(common_random
 opencensus_lib(common_stats_object DEPS absl::time)
 
 # Define NOMINMAX to fix build errors when compiling with MSVC.
-target_compile_definitions(opencensus_common_stats_object INTERFACE $<$<CXX_COMPILER_ID:MSVC>:NOMINMAX>)
+target_compile_definitions(opencensus_common_stats_object INTERFACE
+                           $<$<CXX_COMPILER_ID:MSVC>:NOMINMAX>)
 
 opencensus_lib(common_string_vector_hash)
 

--- a/opencensus/common/internal/CMakeLists.txt
+++ b/opencensus/common/internal/CMakeLists.txt
@@ -24,6 +24,7 @@ opencensus_lib(common_random
 
 opencensus_lib(common_stats_object DEPS absl::time)
 
+# Defines NOMINMAX when compiling with MSVC to fix build errors
 target_compile_definitions(opencensus_common_stats_object INTERFACE $<$<CXX_COMPILER_ID:MSVC>:NOMINMAX>)
 
 opencensus_lib(common_string_vector_hash)

--- a/opencensus/common/internal/CMakeLists.txt
+++ b/opencensus/common/internal/CMakeLists.txt
@@ -24,6 +24,8 @@ opencensus_lib(common_random
 
 opencensus_lib(common_stats_object DEPS absl::time)
 
+target_compile_definitions(opencensus_common_stats_object INTERFACE $<$<CXX_COMPILER_ID:MSVC>:NOMINMAX>)
+
 opencensus_lib(common_string_vector_hash)
 
 opencensus_test(common_random_test random_test.cc common_random)

--- a/opencensus/stats/CMakeLists.txt
+++ b/opencensus/stats/CMakeLists.txt
@@ -54,6 +54,7 @@ opencensus_lib(stats_core
                absl::optional
                absl::span)
 
+# Defines NOMINMAX when compiling with MSVC to fix build errors
 target_compile_definitions(opencensus_stats_core PUBLIC $<$<CXX_COMPILER_ID:MSVC>:NOMINMAX>)
 
 opencensus_lib(stats_recording

--- a/opencensus/stats/CMakeLists.txt
+++ b/opencensus/stats/CMakeLists.txt
@@ -54,6 +54,8 @@ opencensus_lib(stats_core
                absl::optional
                absl::span)
 
+target_compile_definitions(opencensus_stats_core PUBLIC $<$<CXX_COMPILER_ID:MSVC>:NOMINMAX>)
+
 opencensus_lib(stats_recording
                SRCS
                internal/recording.cc

--- a/opencensus/stats/CMakeLists.txt
+++ b/opencensus/stats/CMakeLists.txt
@@ -55,7 +55,8 @@ opencensus_lib(stats_core
                absl::span)
 
 # Define NOMINMAX to fix build errors when compiling with MSVC.
-target_compile_definitions(opencensus_stats_core PUBLIC $<$<CXX_COMPILER_ID:MSVC>:NOMINMAX>)
+target_compile_definitions(opencensus_stats_core PUBLIC
+                           $<$<CXX_COMPILER_ID:MSVC>:NOMINMAX>)
 
 opencensus_lib(stats_recording
                SRCS

--- a/opencensus/stats/CMakeLists.txt
+++ b/opencensus/stats/CMakeLists.txt
@@ -54,7 +54,7 @@ opencensus_lib(stats_core
                absl::optional
                absl::span)
 
-# Defines NOMINMAX when compiling with MSVC to fix build errors
+# Define NOMINMAX to fix build errors when compiling with MSVC.
 target_compile_definitions(opencensus_stats_core PUBLIC $<$<CXX_COMPILER_ID:MSVC>:NOMINMAX>)
 
 opencensus_lib(stats_recording


### PR DESCRIPTION
This adds NOMINMAX as a public/interface definition to the targets `opencensus_common_stats_object` and `opencensus_stats_core` 