### PR TITLE
Remove --experimental_enable_repo_mapping.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -4,8 +4,6 @@
 # Needed by gRPC to build on some platforms.
 build --copt -DGRPC_BAZEL_BUILD
 
-common --experimental_enable_repo_mapping
-
 # --config=asan : Address Sanitizer.
 common:asan --copt -fsanitize=address
 common:asan --copt -DADDRESS_SANITIZER


### PR DESCRIPTION
bazel 0.24.1 doesn't support it, and we haven't used it since
commit 11f65c83459b4d2aafe47feed16bf458a5c3b088.