### PR TITLE
Pin cmake_format to version 0.4.5.

### DIFF
--- a/tools/docker-format/Dockerfile
+++ b/tools/docker-format/Dockerfile
@@ -3,6 +3,6 @@ FROM ubuntu:cosmic
 RUN apt update && \
     apt install -y clang-format golang git python-pip && \
     go get -v github.com/bazelbuild/buildtools/buildifier && \
-    pip install cmake_format
+    pip install cmake_format==0.4.5
 
 CMD ["/bin/bash"]

--- a/tools/travis/check_format.sh
+++ b/tools/travis/check_format.sh
@@ -21,6 +21,6 @@ if ! which buildifier >/dev/null; then
   go get -v github.com/bazelbuild/buildtools/buildifier
 fi
 # Install cmake-format.
-pip install --user cmake_format
+pip install --user cmake_format==0.4.5
 # Check format.
 tools/format.sh


### PR DESCRIPTION
Version 0.5.1 changes the formatting (which breaks "check format" on
travis) but also breaks add_library(ALIAS) so we can't upgrade.

Upstream issue: https://github.com/cheshirekow/cmake_format/issues/111