### PR TITLE
Unpin cmake_format after v0.5.2 bug fixes.

### DIFF
--- a/cmake/OpenCensusDeps.cmake
+++ b/cmake/OpenCensusDeps.cmake
@@ -14,28 +14,20 @@
 
 include(FetchContent)
 
-fetchcontent_declare(googletest
-                     GIT_REPOSITORY
-                     https://github.com/abseil/googletest
-                     GIT_TAG
-                     ed2fe122f8dc9aca844d724986d1d5cf5b65ea4e)
-fetchcontent_declare(abseil
-                     GIT_REPOSITORY
-                     https://github.com/abseil/abseil-cpp
-                     GIT_TAG
-                     2c8421e1c6cef0da9e8a20b01c15256ec9ec116d)
-fetchcontent_declare(prometheus
-                     GIT_REPOSITORY
-                     https://github.com/jupp0r/prometheus-cpp
-                     GIT_TAG
-                     master)
-fetchcontent_declare(benchmark
-                     GIT_REPOSITORY
-                     https://github.com/google/benchmark
-                     GIT_TAG
-                     master)
+FetchContent_Declare(googletest
+                     GIT_REPOSITORY https://github.com/abseil/googletest
+                     GIT_TAG ed2fe122f8dc9aca844d724986d1d5cf5b65ea4e)
+FetchContent_Declare(abseil
+                     GIT_REPOSITORY https://github.com/abseil/abseil-cpp
+                     GIT_TAG 2c8421e1c6cef0da9e8a20b01c15256ec9ec116d)
+FetchContent_Declare(prometheus
+                     GIT_REPOSITORY https://github.com/jupp0r/prometheus-cpp
+                     GIT_TAG master)
+FetchContent_Declare(benchmark
+                     GIT_REPOSITORY https://github.com/google/benchmark
+                     GIT_TAG master)
 
-fetchcontent_getproperties(googletest)
+FetchContent_GetProperties(googletest)
 if(BUILD_TESTING)
   message(STATUS "Dependency: googletest (BUILD_TESTING=${BUILD_TESTING})")
   if(NOT googletest_POPULATED)
@@ -52,44 +44,44 @@ if(BUILD_TESTING)
         ON)
     endif()
 
-    fetchcontent_populate(googletest)
+    FetchContent_Populate(googletest)
     add_subdirectory(${googletest_SOURCE_DIR} ${googletest_BINARY_DIR}
                      EXCLUDE_FROM_ALL)
   endif()
 endif()
 
-fetchcontent_getproperties(abseil)
+FetchContent_GetProperties(abseil)
 if(NOT abseil_POPULATED)
   message(STATUS "Dependency: abseil")
-  fetchcontent_populate(abseil)
+  FetchContent_Populate(abseil)
   add_subdirectory(${abseil_SOURCE_DIR} ${abseil_BINARY_DIR} EXCLUDE_FROM_ALL)
 endif()
 
-fetchcontent_getproperties(prometheus)
+FetchContent_GetProperties(prometheus)
 if(NOT prometheus_POPULATED)
   message(STATUS "Dependency: prometheus")
   set(ENABLE_PUSH OFF CACHE BOOL "Build prometheus-cpp push library" FORCE)
   set(ENABLE_PULL OFF CACHE BOOL "Build prometheus-cpp pull library" FORCE)
-  set(ENABLE_COMPRESSION OFF
-      CACHE BOOL "Enable gzip compression for prometheus-cpp"
-      FORCE)
+  set(ENABLE_COMPRESSION
+      OFF
+      CACHE BOOL "Enable gzip compression for prometheus-cpp" FORCE)
   set(ENABLE_TESTING OFF CACHE BOOL "Build test for prometheus-cpp" FORCE)
-  fetchcontent_populate(prometheus)
+  FetchContent_Populate(prometheus)
   add_subdirectory(${prometheus_SOURCE_DIR} ${prometheus_BINARY_DIR}
                    EXCLUDE_FROM_ALL)
 endif()
 
-fetchcontent_getproperties(benchmark)
+FetchContent_GetProperties(benchmark)
 if(BUILD_TESTING)
   message(STATUS "Dependency: benchmark (BUILD_TESTING=${BUILD_TESTING})")
   if(NOT benchmark_POPULATED)
-    set(BENCHMARK_ENABLE_TESTING OFF
-        CACHE BOOL "Enable testing of the benchmark library."
-        FORCE)
-    set(BENCHMARK_ENABLE_GTEST_TESTS OFF
-        CACHE BOOL "Enable building the unit tests which depend on gtest"
-        FORCE)
-    fetchcontent_populate(benchmark)
+    set(BENCHMARK_ENABLE_TESTING
+        OFF
+        CACHE BOOL "Enable testing of the benchmark library." FORCE)
+    set(BENCHMARK_ENABLE_GTEST_TESTS
+        OFF
+        CACHE BOOL "Enable building the unit tests which depend on gtest" FORCE)
+    FetchContent_Populate(benchmark)
     add_subdirectory(${benchmark_SOURCE_DIR} ${benchmark_BINARY_DIR}
                      EXCLUDE_FROM_ALL)
   endif()

--- a/cmake/OpenCensusHelpers.cmake
+++ b/cmake/OpenCensusHelpers.cmake
@@ -33,7 +33,10 @@ function(opencensus_test NAME SRC)
     set(_NAME "opencensus_${NAME}")
     add_executable(${_NAME} ${SRC})
     prepend_opencensus(DEPS "${ARGN}")
-    target_link_libraries(${_NAME} "${DEPS}" gmock gtest_main)
+    target_link_libraries(${_NAME}
+                          "${DEPS}"
+                          gmock
+                          gtest_main)
     add_test(NAME ${_NAME} COMMAND ${_NAME})
   endif()
 endfunction()
@@ -54,7 +57,11 @@ endfunction()
 # Helper function like bazel's cc_library.  Libraries are namespaced as
 # opencensus_* and public libraries are also aliased as opencensus-cpp::*.
 function(opencensus_lib NAME)
-  cmake_parse_arguments(ARG "PUBLIC" "" "SRCS;DEPS" ${ARGN})
+  cmake_parse_arguments(ARG
+                        "PUBLIC"
+                        ""
+                        "SRCS;DEPS"
+                        ${ARGN})
   set(_NAME "opencensus_${NAME}")
   prepend_opencensus(ARG_DEPS "${ARG_DEPS}")
   if(ARG_SRCS)

--- a/opencensus/stats/CMakeLists.txt
+++ b/opencensus/stats/CMakeLists.txt
@@ -12,7 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-opencensus_lib(stats PUBLIC DEPS stats_core stats_recording)
+opencensus_lib(stats
+               PUBLIC
+               DEPS
+               stats_core
+               stats_recording)
 
 opencensus_lib(stats_test_utils
                PUBLIC

--- a/opencensus/trace/CMakeLists.txt
+++ b/opencensus/trace/CMakeLists.txt
@@ -148,7 +148,10 @@ opencensus_test(trace_sampler_test
                 absl::synchronization
                 absl::time)
 
-opencensus_test(trace_span_test internal/span_test.cc trace absl::strings)
+opencensus_test(trace_span_test
+                internal/span_test.cc
+                trace
+                absl::strings)
 
 opencensus_test(trace_span_id_test internal/span_id_test.cc trace)
 
@@ -172,7 +175,10 @@ opencensus_test(trace_span_exporter_test
                 absl::synchronization
                 absl::time)
 
-opencensus_test(trace_status_test internal/status_test.cc trace absl::strings)
+opencensus_test(trace_status_test
+                internal/status_test.cc
+                trace
+                absl::strings)
 
 opencensus_test(trace_trace_config_test
                 internal/trace_config_test.cc

--- a/tools/docker-format/Dockerfile
+++ b/tools/docker-format/Dockerfile
@@ -3,6 +3,6 @@ FROM ubuntu:cosmic
 RUN apt update && \
     apt install -y clang-format golang git python-pip && \
     go get -v github.com/bazelbuild/buildtools/buildifier && \
-    pip install cmake_format==0.4.5
+    pip install 'cmake_format>=0.5.2'
 
 CMD ["/bin/bash"]

--- a/tools/format.sh
+++ b/tools/format.sh
@@ -77,7 +77,7 @@ if [[ "$tools_check" == "y" ]]; then
       -name '*.cmake' -print)
   else
     echo "Can't find cmake-format. It can be installed with:"
-    echo "  pip install --user cmake_format"
+    echo "  pip install --user 'cmake_format>=0.5.2'"
   fi
 fi
 

--- a/tools/travis/check_format.sh
+++ b/tools/travis/check_format.sh
@@ -21,6 +21,6 @@ if ! which buildifier >/dev/null; then
   go get -v github.com/bazelbuild/buildtools/buildifier
 fi
 # Install cmake-format.
-pip install --user cmake_format==0.4.5
+pip install --user 'cmake_format>=0.5.2'
 # Check format.
 tools/format.sh


### PR DESCRIPTION
This is a followup to #317.