### PR TITLE
Move RAPIDJSON_HAS_STDSTRING define to Zipkin exporter code.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -123,7 +123,6 @@ cc_library(
         "include/rapidjson/error/*.h",
     ]),
     includes = ["include/"],
-    defines = ["RAPIDJSON_HAS_STDSTRING=1",],
     visibility = ["//visibility:public"],
 )
 """,

--- a/opencensus/exporters/trace/zipkin/internal/zipkin_exporter.cc
+++ b/opencensus/exporters/trace/zipkin/internal/zipkin_exporter.cc
@@ -19,6 +19,8 @@
 #include <iostream>
 
 #include <curl/curl.h>
+#undef RAPIDJSON_HAS_STDSTRING
+#define RAPIDJSON_HAS_STDSTRING 1
 #include <rapidjson/prettywriter.h>
 #include <rapidjson/stringbuffer.h>
 #include "absl/memory/memory.h"


### PR DESCRIPTION
This is cleaner than having it in the build rule.