### PR TITLE
zlib build fix.

### DIFF
--- a/tools/zlib/BUILD
+++ b/tools/zlib/BUILD
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# @com_github_madler_zlib comes from grpc_deps in the outer workspace.
+# @zlib comes from grpc_deps in the outer workspace.
 
 cc_library(
     name = "z",
     visibility = ["//visibility:public"],
-    deps = ["@com_github_madler_zlib//:z"],
+    deps = ["@zlib//:zlib"],
 )

--- a/tools/zlib/BUILD
+++ b/tools/zlib/BUILD
@@ -17,5 +17,5 @@
 cc_library(
     name = "z",
     visibility = ["//visibility:public"],
-    deps = ["@zlib//:zlib"],
+    deps = ["@zlib"],
 )


### PR DESCRIPTION
grpc renamed @com_github_madler_zlib//:z to @zlib//:zlib in
https://github.com/grpc/grpc/commit/79f7abb45eab9f6f49ba694d4f8ce70f8e142b1d#diff-5952172e3b803ed640371cda4cddf13d