### PR TITLE
Add Span::SetName()

### DIFF
--- a/opencensus/trace/internal/span.cc
+++ b/opencensus/trace/internal/span.cc
@@ -202,6 +202,12 @@ void Span::SetStatus(StatusCode canonical_code,
   }
 }
 
+void Span::SetName(absl::string_view message) const {
+  if (IsRecording()) {
+    span_impl_->SetName(message);
+  }
+}
+
 void Span::End() const {
   if (IsRecording()) {
     if (!span_impl_->End()) {

--- a/opencensus/trace/internal/span.cc
+++ b/opencensus/trace/internal/span.cc
@@ -202,9 +202,9 @@ void Span::SetStatus(StatusCode canonical_code,
   }
 }
 
-void Span::SetName(absl::string_view message) const {
+void Span::SetName(absl::string_view name) const {
   if (IsRecording()) {
-    span_impl_->SetName(message);
+    span_impl_->SetName(name);
   }
 }
 

--- a/opencensus/trace/internal/span_impl.cc
+++ b/opencensus/trace/internal/span_impl.cc
@@ -137,6 +137,13 @@ void SpanImpl::SetStatus(exporter::Status&& status) {
   }
 }
 
+void SpanImpl::SetName(absl::string_view name) {
+  absl::MutexLock l(&mu_);
+  if (!has_ended_) {
+    name_ = std::string(name);
+  }
+}
+
 bool SpanImpl::End() {
   absl::MutexLock l(&mu_);
   if (has_ended_) {

--- a/opencensus/trace/internal/span_impl.h
+++ b/opencensus/trace/internal/span_impl.h
@@ -121,7 +121,7 @@ class SpanImpl final {
   // The status of the span. Only set if start_options_.record_events is true.
   exporter::Status status_ GUARDED_BY(mu_);
   // The displayed name of the span.
-  std::string name_;
+  std::string name_ GUARDED_BY(mu_);
   // The parent SpanId of this span. Parent SpanId will be not valid if this is
   // a root span.
   const SpanId parent_span_id_;

--- a/opencensus/trace/internal/span_impl.h
+++ b/opencensus/trace/internal/span_impl.h
@@ -85,6 +85,8 @@ class SpanImpl final {
 
   void SetStatus(exporter::Status&& status) LOCKS_EXCLUDED(mu_);
 
+  void SetName(absl::string_view name);
+
   // Returns true on success (if this is the first time the Span has ended) and
   // also marks the end of the Span and sets its end_time_.
   bool End() LOCKS_EXCLUDED(mu_);
@@ -119,7 +121,7 @@ class SpanImpl final {
   // The status of the span. Only set if start_options_.record_events is true.
   exporter::Status status_ GUARDED_BY(mu_);
   // The displayed name of the span.
-  const std::string name_;
+  std::string name_;
   // The parent SpanId of this span. Parent SpanId will be not valid if this is
   // a root span.
   const SpanId parent_span_id_;

--- a/opencensus/trace/internal/span_impl.h
+++ b/opencensus/trace/internal/span_impl.h
@@ -85,7 +85,7 @@ class SpanImpl final {
 
   void SetStatus(exporter::Status&& status) LOCKS_EXCLUDED(mu_);
 
-  void SetName(absl::string_view name);
+  void SetName(absl::string_view name) LOCKS_EXCLUDED(mu_);
 
   // Returns true on success (if this is the first time the Span has ended) and
   // also marks the end of the Span and sets its end_time_.

--- a/opencensus/trace/internal/span_test.cc
+++ b/opencensus/trace/internal/span_test.cc
@@ -203,6 +203,9 @@ TEST(SpanTest, FullSpanTest) {
 
   span.SetStatus(StatusCode::DEADLINE_EXCEEDED, "desc");
 
+  // Change span name
+  span.SetName("NewSpanName");
+
   EXPECT_TRUE(span.context().IsValid());
   span.End();
   // Add a few extra things and make sure they are NOT included since the span
@@ -213,7 +216,7 @@ TEST(SpanTest, FullSpanTest) {
 
   const exporter::SpanData data = SpanTestPeer::ToSpanData(&span);
 
-  EXPECT_EQ("MyRootSpan", data.name());
+  EXPECT_EQ("NewSpanName", data.name());
   EXPECT_EQ(parent.context().span_id(), data.parent_span_id());
   EXPECT_EQ(0, data.annotations().dropped_events_count());
   EXPECT_EQ(0, data.message_events().dropped_events_count());

--- a/opencensus/trace/span.h
+++ b/opencensus/trace/span.h
@@ -154,6 +154,9 @@ class Span final {
   void SetStatus(StatusCode canonical_code,
                  absl::string_view message = "") const;
 
+  // Set the span name.
+  void SetName(absl::string_view name) const;
+
   // Marks the end of a Span. No further changes can be made to the Span after
   // End is called.
   void End() const;

--- a/tools/travis/build_bazel.sh
+++ b/tools/travis/build_bazel.sh
@@ -27,9 +27,11 @@ if [[ "$TRAVIS_COMPILER" = "clang" ]]; then
   export BAZEL_OPTIONS="$BAZEL_OPTIONS --copt=-Werror=thread-safety"
 fi
 
-wget https://github.com/bazelbuild/bazel/releases/download/0.20.0/bazel-0.20.0-installer-${BAZEL_OS}-x86_64.sh
-chmod +x bazel-0.20.0-installer-${BAZEL_OS}-x86_64.sh
-./bazel-0.20.0-installer-${BAZEL_OS}-x86_64.sh --user
+export BAZEL_VERSION="0.24.1"
+
+wget https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-installer-${BAZEL_OS}-x86_64.sh
+chmod +x bazel-${BAZEL_VERSION}-installer-${BAZEL_OS}-x86_64.sh
+./bazel-${BAZEL_VERSION}-installer-${BAZEL_OS}-x86_64.sh --user
 echo "build --disk_cache=$HOME/bazel-cache" > ~/.bazelrc
 echo "build --experimental_strict_action_env" >> ~/.bazelrc
 du -sk $HOME/bazel-cache || true


### PR DESCRIPTION
Allows changing the span name after the constructor before the span end.

This is needed for envoyproxy/envoy which updates the span name during the request route configuration.
Currently, it uses an annotation which leads to strange span values:
```
Name: ingress (From Client)
TraceId-SpanId-Options: 09d76941cce57c762c600ad861e120e3-57f2c613dc9714a0-01
Parent SpanId: 91b716c92ee92e57 (remote: true)
Start time: 2019-06-24T13:47:07.150968383-07:00
End time: 2019-06-24T13:47:07.153027742-07:00
Attributes: (0 dropped)
Annotations: (0 dropped)
  2019-06-24T13:47:07.151008446-07:00: setOperation (attributes: "operation":"ServerRoute")
  2019-06-24T13:47:07.151011373-07:00: setOperation (attributes: "operation":"ClientRoute")
Message events: (0 dropped)
Links: (0 dropped)
Span ended: true
Status: OK
```

We should not be seeing the server operation in the client span. Instead, the span name should be ClientRoute. 

Signed-off-by: Kuat Yessenov <kuat@google.com>