### PR TITLE
override sampling decision

### DIFF
--- a/opencensus/trace/internal/span.cc
+++ b/opencensus/trace/internal/span.cc
@@ -224,6 +224,8 @@ const SpanContext& Span::context() const { return context_; }
 
 bool Span::IsSampled() const { return context_.trace_options().IsSampled(); }
 
+void Span::StopRecording() { span_impl_ = nullptr; }
+
 bool Span::IsRecording() const { return span_impl_ != nullptr; }
 
 void swap(Span& a, Span& b) {

--- a/opencensus/trace/span.h
+++ b/opencensus/trace/span.h
@@ -168,6 +168,11 @@ class Span final {
   // Sampled spans always record events.
   bool IsSampled() const;
 
+  // Stops recording the span and overrides the sampling decision to false.
+  // This should be used by the client to force disable sampling in support of
+  // delayed sampling decisions (e.g. health check URI blacklist).
+  void StopRecording();
+
   // Returns true if the Span is recording events (will appear in Span stores).
   // Sampled spans always record events, but not all Spans that are recording
   // are sampled.


### PR DESCRIPTION
Clients of opencensus may want to delay the sampling decision until after the span has been created.
For example, at the time envoyproxy decides whether a request is a health check or not, it may already have started recording the span:
1. Envoy receives a request.
2. Envoy creates a child span for an external authorization sub-request.
3. Envoy applies a health check blacklist, may want to stop sampling the span and its children.
4. Envoy proceedes forwarding the request.

To support this use case, other tracers expose a `setSampling` override. I think it's sufficient to stop recording the span for this case, e.g. only override the sampling decision to false.

Signed-off-by: Kuat Yessenov <kuat@google.com>