### PR TITLE
Add per view monitored resource into stackdriver exporter option

### DIFF
--- a/opencensus/exporters/stats/stackdriver/internal/stackdriver_exporter.cc
+++ b/opencensus/exporters/stats/stackdriver/internal/stackdriver_exporter.cc
@@ -96,7 +96,8 @@ void Handler::ExportViewData(
     }
     const auto view_time_series =
         MakeTimeSeries(metric_name_prefix_, opts_.monitored_resource,
-                       datum.first, datum.second, opts_.opencensus_task);
+                       opts_.per_view_monitored_resource, datum.first,
+                       datum.second, opts_.opencensus_task);
     time_series.insert(time_series.end(), view_time_series.begin(),
                        view_time_series.end());
   }

--- a/opencensus/exporters/stats/stackdriver/internal/stackdriver_exporter.cc
+++ b/opencensus/exporters/stats/stackdriver/internal/stackdriver_exporter.cc
@@ -96,7 +96,7 @@ void Handler::ExportViewData(
     }
     const auto view_time_series =
         MakeTimeSeries(metric_name_prefix_, opts_.monitored_resource,
-                       opts_.per_view_monitored_resource, datum.first,
+                       opts_.per_metric_monitored_resource, datum.first,
                        datum.second, opts_.opencensus_task);
     time_series.insert(time_series.end(), view_time_series.begin(),
                        view_time_series.end());

--- a/opencensus/exporters/stats/stackdriver/internal/stackdriver_utils.cc
+++ b/opencensus/exporters/stats/stackdriver/internal/stackdriver_utils.cc
@@ -190,10 +190,9 @@ std::vector<google::monitoring::v3::TimeSeries> MakeTimeSeries(
   auto base_time_series = google::monitoring::v3::TimeSeries();
   base_time_series.mutable_metric()->set_type(
       MakeType(metric_name_prefix, view_descriptor.name()));
-  if (per_view_monitored_resource.find(view_descriptor.name()) !=
-      per_view_monitored_resource.end()) {
-    *base_time_series.mutable_resource() =
-        per_view_monitored_resource.at(view_descriptor.name());
+  auto iter = per_view_monitored_resource.find(view_descriptor.name());
+  if (iter != per_view_monitored_resource.end()) {
+    *base_time_series.mutable_resource() = iter->second;
   } else if (monitored_resource.type().empty()) {
     base_time_series.mutable_resource()->set_type(kDefaultResourceType);
   } else {

--- a/opencensus/exporters/stats/stackdriver/internal/stackdriver_utils.cc
+++ b/opencensus/exporters/stats/stackdriver/internal/stackdriver_utils.cc
@@ -181,6 +181,8 @@ void SetMetricDescriptor(
 std::vector<google::monitoring::v3::TimeSeries> MakeTimeSeries(
     absl::string_view metric_name_prefix,
     const google::api::MonitoredResource& monitored_resource,
+    const std::unordered_map<std::string, google::api::MonitoredResource>&
+        per_view_monitored_resource,
     const opencensus::stats::ViewDescriptor& view_descriptor,
     const opencensus::stats::ViewData& data,
     absl::string_view opencensus_task) {
@@ -188,7 +190,11 @@ std::vector<google::monitoring::v3::TimeSeries> MakeTimeSeries(
   auto base_time_series = google::monitoring::v3::TimeSeries();
   base_time_series.mutable_metric()->set_type(
       MakeType(metric_name_prefix, view_descriptor.name()));
-  if (monitored_resource.type().empty()) {
+  if (per_view_monitored_resource.find(view_descriptor.name()) !=
+      per_view_monitored_resource.end()) {
+    *base_time_series.mutable_resource() =
+        per_view_monitored_resource.at(view_descriptor.name());
+  } else if (monitored_resource.type().empty()) {
     base_time_series.mutable_resource()->set_type(kDefaultResourceType);
   } else {
     *base_time_series.mutable_resource() = monitored_resource;

--- a/opencensus/exporters/stats/stackdriver/internal/stackdriver_utils.cc
+++ b/opencensus/exporters/stats/stackdriver/internal/stackdriver_utils.cc
@@ -182,7 +182,7 @@ std::vector<google::monitoring::v3::TimeSeries> MakeTimeSeries(
     absl::string_view metric_name_prefix,
     const google::api::MonitoredResource& monitored_resource,
     const std::unordered_map<std::string, google::api::MonitoredResource>&
-        per_view_monitored_resource,
+        per_metric_monitored_resource,
     const opencensus::stats::ViewDescriptor& view_descriptor,
     const opencensus::stats::ViewData& data,
     absl::string_view opencensus_task) {
@@ -190,8 +190,8 @@ std::vector<google::monitoring::v3::TimeSeries> MakeTimeSeries(
   auto base_time_series = google::monitoring::v3::TimeSeries();
   base_time_series.mutable_metric()->set_type(
       MakeType(metric_name_prefix, view_descriptor.name()));
-  auto iter = per_view_monitored_resource.find(view_descriptor.name());
-  if (iter != per_view_monitored_resource.end()) {
+  auto iter = per_metric_monitored_resource.find(view_descriptor.name());
+  if (iter != per_metric_monitored_resource.end()) {
     *base_time_series.mutable_resource() = iter->second;
   } else if (monitored_resource.type().empty()) {
     base_time_series.mutable_resource()->set_type(kDefaultResourceType);

--- a/opencensus/exporters/stats/stackdriver/internal/stackdriver_utils.h
+++ b/opencensus/exporters/stats/stackdriver/internal/stackdriver_utils.h
@@ -40,6 +40,8 @@ void SetMetricDescriptor(
 std::vector<google::monitoring::v3::TimeSeries> MakeTimeSeries(
     absl::string_view metric_name_prefix,
     const google::api::MonitoredResource& monitored_resource,
+    const std::unordered_map<std::string, google::api::MonitoredResource>&
+        per_view_monitored_resource,
     const opencensus::stats::ViewDescriptor& view_descriptor,
     const opencensus::stats::ViewData& data, absl::string_view opencensus_task);
 

--- a/opencensus/exporters/stats/stackdriver/internal/stackdriver_utils.h
+++ b/opencensus/exporters/stats/stackdriver/internal/stackdriver_utils.h
@@ -41,7 +41,7 @@ std::vector<google::monitoring::v3::TimeSeries> MakeTimeSeries(
     absl::string_view metric_name_prefix,
     const google::api::MonitoredResource& monitored_resource,
     const std::unordered_map<std::string, google::api::MonitoredResource>&
-        per_view_monitored_resource,
+        per_metric_monitored_resource,
     const opencensus::stats::ViewDescriptor& view_descriptor,
     const opencensus::stats::ViewData& data, absl::string_view opencensus_task);
 

--- a/opencensus/exporters/stats/stackdriver/internal/stackdriver_utils_test.cc
+++ b/opencensus/exporters/stats/stackdriver/internal/stackdriver_utils_test.cc
@@ -255,10 +255,10 @@ TEST(StackdriverUtilsTest, MakeTimeSeriesPerViewCustomResource) {
   (*resource.mutable_labels())["instance_id"] = "1234";
   (*resource.mutable_labels())["zone"] = "my_zone";
   std::unordered_map<std::string, google::api::MonitoredResource>
-      per_view_resources;
-  per_view_resources[view_name] = resource;
+      per_metric_resources;
+  per_metric_resources[view_name] = resource;
   const std::vector<google::monitoring::v3::TimeSeries> time_series =
-      MakeTimeSeries("", DefaultResource(), per_view_resources, view_descriptor,
+      MakeTimeSeries("", DefaultResource(), per_metric_resources, view_descriptor,
                      data, task);
   ASSERT_EQ(1, time_series.size());
   const auto& ts = time_series.front();
@@ -290,10 +290,10 @@ TEST(StackdriverUtilsTest, MakeTimeSeriesPerViewCustomResourceNotMatch) {
   (*resource.mutable_labels())["instance_id"] = "1234";
   (*resource.mutable_labels())["zone"] = "my_zone";
   std::unordered_map<std::string, google::api::MonitoredResource>
-      per_view_resources;
-  per_view_resources["some_other_view"] = resource;
+      per_metric_resources;
+  per_metric_resources["some_other_view"] = resource;
   const std::vector<google::monitoring::v3::TimeSeries> time_series =
-      MakeTimeSeries("", DefaultResource(), per_view_resources, view_descriptor,
+      MakeTimeSeries("", DefaultResource(), per_metric_resources, view_descriptor,
                      data, task);
   ASSERT_EQ(1, time_series.size());
   const auto& ts = time_series.front();

--- a/opencensus/exporters/stats/stackdriver/internal/stackdriver_utils_test.cc
+++ b/opencensus/exporters/stats/stackdriver/internal/stackdriver_utils_test.cc
@@ -258,8 +258,8 @@ TEST(StackdriverUtilsTest, MakeTimeSeriesPerMetricCustomResource) {
       per_metric_resources;
   per_metric_resources[view_name] = resource;
   const std::vector<google::monitoring::v3::TimeSeries> time_series =
-      MakeTimeSeries("", DefaultResource(), per_metric_resources, view_descriptor,
-                     data, task);
+      MakeTimeSeries("", DefaultResource(), per_metric_resources,
+                     view_descriptor, data, task);
   ASSERT_EQ(1, time_series.size());
   const auto& ts = time_series.front();
   EXPECT_EQ("gce_instance", ts.resource().type());
@@ -293,8 +293,8 @@ TEST(StackdriverUtilsTest, MakeTimeSeriesPerMetricCustomResourceNotMatch) {
       per_metric_resources;
   per_metric_resources["some_other_view"] = resource;
   const std::vector<google::monitoring::v3::TimeSeries> time_series =
-      MakeTimeSeries("", DefaultResource(), per_metric_resources, view_descriptor,
-                     data, task);
+      MakeTimeSeries("", DefaultResource(), per_metric_resources,
+                     view_descriptor, data, task);
   ASSERT_EQ(1, time_series.size());
   const auto& ts = time_series.front();
   EXPECT_EQ("global", ts.resource().type());

--- a/opencensus/exporters/stats/stackdriver/internal/stackdriver_utils_test.cc
+++ b/opencensus/exporters/stats/stackdriver/internal/stackdriver_utils_test.cc
@@ -42,7 +42,7 @@ google::api::MonitoredResource DefaultResource() {
 }
 
 std::unordered_map<std::string, google::api::MonitoredResource>
-DefaultPerViewResource() {
+DefaultPerMetricResource() {
   return std::unordered_map<std::string, google::api::MonitoredResource>();
 }
 
@@ -196,7 +196,7 @@ TEST(StackdriverUtilsTest, MakeTimeSeriesDefaultResource) {
   const opencensus::stats::ViewData data =
       TestUtils::MakeViewData(view_descriptor, {{{}, 1.0}});
   const std::vector<google::monitoring::v3::TimeSeries> time_series =
-      MakeTimeSeries("", DefaultResource(), DefaultPerViewResource(),
+      MakeTimeSeries("", DefaultResource(), DefaultPerMetricResource(),
                      view_descriptor, data, task);
   ASSERT_EQ(1, time_series.size());
   const auto& ts = time_series.front();
@@ -222,7 +222,7 @@ TEST(StackdriverUtilsTest, MakeTimeSeriesCustomResource) {
   (*resource.mutable_labels())["instance_id"] = "1234";
   (*resource.mutable_labels())["zone"] = "my_zone";
   const std::vector<google::monitoring::v3::TimeSeries> time_series =
-      MakeTimeSeries("", resource, DefaultPerViewResource(), view_descriptor,
+      MakeTimeSeries("", resource, DefaultPerMetricResource(), view_descriptor,
                      data, task);
   ASSERT_EQ(1, time_series.size());
   const auto& ts = time_series.front();
@@ -237,7 +237,7 @@ TEST(StackdriverUtilsTest, MakeTimeSeriesCustomResource) {
       << ts.resource().DebugString();
 }
 
-TEST(StackdriverUtilsTest, MakeTimeSeriesPerViewCustomResource) {
+TEST(StackdriverUtilsTest, MakeTimeSeriesPerMetricCustomResource) {
   const auto measure =
       opencensus::stats::MeasureDouble::Register("my_measure", "", "");
   const std::string task = "test_task";
@@ -272,7 +272,7 @@ TEST(StackdriverUtilsTest, MakeTimeSeriesPerViewCustomResource) {
       << ts.resource().DebugString();
 }
 
-TEST(StackdriverUtilsTest, MakeTimeSeriesPerViewCustomResourceNotMatch) {
+TEST(StackdriverUtilsTest, MakeTimeSeriesPerMetricCustomResourceNotMatch) {
   const auto measure =
       opencensus::stats::MeasureDouble::Register("my_measure", "", "");
   const std::string task = "test_task";
@@ -320,7 +320,7 @@ TEST(StackdriverUtilsTest, MakeTimeSeriesSumDoubleAndTypes) {
       view_descriptor, {{{"v1", "v1"}, 1.0}, {{"v1", "v2"}, 2.0}});
   const std::vector<google::monitoring::v3::TimeSeries> time_series =
       MakeTimeSeries(metric_name_prefix, DefaultResource(),
-                     DefaultPerViewResource(), view_descriptor, data, task);
+                     DefaultPerMetricResource(), view_descriptor, data, task);
 
   for (const auto& ts : time_series) {
     EXPECT_EQ("custom.googleapis.com/test/test_view", ts.metric().type());
@@ -360,7 +360,7 @@ TEST(StackdriverUtilsTest, MakeTimeSeriesSumInt) {
   const opencensus::stats::ViewData data = TestUtils::MakeViewData(
       view_descriptor, {{{"v1", "v1"}, 1.0}, {{"v1", "v2"}, 2.0}});
   const std::vector<google::monitoring::v3::TimeSeries> time_series =
-      MakeTimeSeries("", DefaultResource(), DefaultPerViewResource(),
+      MakeTimeSeries("", DefaultResource(), DefaultPerMetricResource(),
                      view_descriptor, data, task);
 
   for (const auto& ts : time_series) {
@@ -401,7 +401,7 @@ TEST(StackdriverUtilsTest, MakeTimeSeriesCountDouble) {
       view_descriptor,
       {{{"v1", "v1"}, 1.0}, {{"v1", "v1"}, 3.0}, {{"v1", "v2"}, 2.0}});
   const std::vector<google::monitoring::v3::TimeSeries> time_series =
-      MakeTimeSeries("", DefaultResource(), DefaultPerViewResource(),
+      MakeTimeSeries("", DefaultResource(), DefaultPerMetricResource(),
                      view_descriptor, data, task);
 
   for (const auto& ts : time_series) {
@@ -445,7 +445,7 @@ TEST(StackdriverUtilsTest, MakeTimeSeriesDistributionDouble) {
       view_descriptor,
       {{{"v1", "v1"}, -1.0}, {{"v1", "v1"}, 7.0}, {{"v1", "v2"}, 1.0}});
   const std::vector<google::monitoring::v3::TimeSeries> time_series =
-      MakeTimeSeries("", DefaultResource(), DefaultPerViewResource(),
+      MakeTimeSeries("", DefaultResource(), DefaultPerMetricResource(),
                      view_descriptor, data, task);
 
   for (const auto& ts : time_series) {
@@ -492,7 +492,7 @@ TEST(StackdriverUtilsTest, MakeTimeSeriesLastValueInt) {
   const opencensus::stats::ViewData data = TestUtils::MakeViewData(
       view_descriptor, {{{"v1", "v1"}, 1.0}, {{"v1", "v2"}, 2.0}});
   const std::vector<google::monitoring::v3::TimeSeries> time_series =
-      MakeTimeSeries("", DefaultResource(), DefaultPerViewResource(),
+      MakeTimeSeries("", DefaultResource(), DefaultPerMetricResource(),
                      view_descriptor, data, task);
 
   for (const auto& ts : time_series) {

--- a/opencensus/exporters/stats/stackdriver/internal/stackdriver_utils_test.cc
+++ b/opencensus/exporters/stats/stackdriver/internal/stackdriver_utils_test.cc
@@ -41,6 +41,11 @@ google::api::MonitoredResource DefaultResource() {
   return google::api::MonitoredResource();
 }
 
+std::unordered_map<std::string, google::api::MonitoredResource>
+DefaultPerViewResource() {
+  return std::unordered_map<std::string, google::api::MonitoredResource>();
+}
+
 TEST(StackdriverUtilsTest, SetMetricDescriptorNameAndType) {
   const std::string project_id = "projects/test-id";
   const std::string metric_name_prefix = "custom.googleapis.com/test/";
@@ -191,7 +196,8 @@ TEST(StackdriverUtilsTest, MakeTimeSeriesDefaultResource) {
   const opencensus::stats::ViewData data =
       TestUtils::MakeViewData(view_descriptor, {{{}, 1.0}});
   const std::vector<google::monitoring::v3::TimeSeries> time_series =
-      MakeTimeSeries("", DefaultResource(), view_descriptor, data, task);
+      MakeTimeSeries("", DefaultResource(), DefaultPerViewResource(),
+                     view_descriptor, data, task);
   ASSERT_EQ(1, time_series.size());
   const auto& ts = time_series.front();
   EXPECT_EQ("global", ts.resource().type());
@@ -216,7 +222,44 @@ TEST(StackdriverUtilsTest, MakeTimeSeriesCustomResource) {
   (*resource.mutable_labels())["instance_id"] = "1234";
   (*resource.mutable_labels())["zone"] = "my_zone";
   const std::vector<google::monitoring::v3::TimeSeries> time_series =
-      MakeTimeSeries("", resource, view_descriptor, data, task);
+      MakeTimeSeries("", resource, DefaultPerViewResource(), view_descriptor,
+                     data, task);
+  ASSERT_EQ(1, time_series.size());
+  const auto& ts = time_series.front();
+  EXPECT_EQ("gce_instance", ts.resource().type());
+  // EXPECT_EQ(0, ts.resource().labels_size());
+  using ::testing::Pair;
+  EXPECT_THAT(ts.resource().labels(),
+              ::testing::UnorderedElementsAre(Pair("project_id", "my_project"),
+                                              Pair("instance_id", "1234"),
+                                              Pair("zone", "my_zone")))
+      << "  resource() is:\n"
+      << ts.resource().DebugString();
+}
+
+TEST(StackdriverUtilsTest, MakeTimeSeriesPerViewCustomResource) {
+  const auto measure =
+      opencensus::stats::MeasureDouble::Register("my_measure", "", "");
+  const std::string task = "test_task";
+  const std::string view_name = "test_view";
+  const auto view_descriptor =
+      opencensus::stats::ViewDescriptor()
+          .set_name(view_name)
+          .set_measure(measure.GetDescriptor().name())
+          .set_aggregation(opencensus::stats::Aggregation::Sum());
+  const opencensus::stats::ViewData data =
+      TestUtils::MakeViewData(view_descriptor, {{{}, 1.0}});
+  google::api::MonitoredResource resource;
+  resource.set_type("gce_instance");
+  (*resource.mutable_labels())["project_id"] = "my_project";
+  (*resource.mutable_labels())["instance_id"] = "1234";
+  (*resource.mutable_labels())["zone"] = "my_zone";
+  std::unordered_map<std::string, google::api::MonitoredResource>
+      per_view_resources;
+  per_view_resources[view_name] = resource;
+  const std::vector<google::monitoring::v3::TimeSeries> time_series =
+      MakeTimeSeries("", DefaultResource(), per_view_resources, view_descriptor,
+                     data, task);
   ASSERT_EQ(1, time_series.size());
   const auto& ts = time_series.front();
   EXPECT_EQ("gce_instance", ts.resource().type());
@@ -248,8 +291,8 @@ TEST(StackdriverUtilsTest, MakeTimeSeriesSumDoubleAndTypes) {
   const opencensus::stats::ViewData data = TestUtils::MakeViewData(
       view_descriptor, {{{"v1", "v1"}, 1.0}, {{"v1", "v2"}, 2.0}});
   const std::vector<google::monitoring::v3::TimeSeries> time_series =
-      MakeTimeSeries(metric_name_prefix, DefaultResource(), view_descriptor,
-                     data, task);
+      MakeTimeSeries(metric_name_prefix, DefaultResource(),
+                     DefaultPerViewResource(), view_descriptor, data, task);
 
   for (const auto& ts : time_series) {
     EXPECT_EQ("custom.googleapis.com/test/test_view", ts.metric().type());
@@ -289,7 +332,8 @@ TEST(StackdriverUtilsTest, MakeTimeSeriesSumInt) {
   const opencensus::stats::ViewData data = TestUtils::MakeViewData(
       view_descriptor, {{{"v1", "v1"}, 1.0}, {{"v1", "v2"}, 2.0}});
   const std::vector<google::monitoring::v3::TimeSeries> time_series =
-      MakeTimeSeries("", DefaultResource(), view_descriptor, data, task);
+      MakeTimeSeries("", DefaultResource(), DefaultPerViewResource(),
+                     view_descriptor, data, task);
 
   for (const auto& ts : time_series) {
     ASSERT_EQ(1, ts.points_size());
@@ -329,7 +373,8 @@ TEST(StackdriverUtilsTest, MakeTimeSeriesCountDouble) {
       view_descriptor,
       {{{"v1", "v1"}, 1.0}, {{"v1", "v1"}, 3.0}, {{"v1", "v2"}, 2.0}});
   const std::vector<google::monitoring::v3::TimeSeries> time_series =
-      MakeTimeSeries("", DefaultResource(), view_descriptor, data, task);
+      MakeTimeSeries("", DefaultResource(), DefaultPerViewResource(),
+                     view_descriptor, data, task);
 
   for (const auto& ts : time_series) {
     ASSERT_EQ(1, ts.points_size());
@@ -372,7 +417,8 @@ TEST(StackdriverUtilsTest, MakeTimeSeriesDistributionDouble) {
       view_descriptor,
       {{{"v1", "v1"}, -1.0}, {{"v1", "v1"}, 7.0}, {{"v1", "v2"}, 1.0}});
   const std::vector<google::monitoring::v3::TimeSeries> time_series =
-      MakeTimeSeries("", DefaultResource(), view_descriptor, data, task);
+      MakeTimeSeries("", DefaultResource(), DefaultPerViewResource(),
+                     view_descriptor, data, task);
 
   for (const auto& ts : time_series) {
     ASSERT_EQ(1, ts.points_size());
@@ -418,7 +464,8 @@ TEST(StackdriverUtilsTest, MakeTimeSeriesLastValueInt) {
   const opencensus::stats::ViewData data = TestUtils::MakeViewData(
       view_descriptor, {{{"v1", "v1"}, 1.0}, {{"v1", "v2"}, 2.0}});
   const std::vector<google::monitoring::v3::TimeSeries> time_series =
-      MakeTimeSeries("", DefaultResource(), view_descriptor, data, task);
+      MakeTimeSeries("", DefaultResource(), DefaultPerViewResource(),
+                     view_descriptor, data, task);
 
   for (const auto& ts : time_series) {
     ASSERT_EQ(1, ts.points_size());

--- a/opencensus/exporters/stats/stackdriver/stackdriver_exporter.h
+++ b/opencensus/exporters/stats/stackdriver/stackdriver_exporter.h
@@ -48,6 +48,19 @@ struct StackdriverOptions {
   // https://cloud.google.com/monitoring/api/resources
   google::api::MonitoredResource monitored_resource;
 
+  // Optional: per view Stackdriver MonitoredResource to use. Key is the view
+  // descriptor name, value is the monitored resource to use for that view.
+  //
+  // If the view name cannot be found in the map, the exporter will use the
+  // "monitored_resource" set in option, or "global" resource if that is not
+  // specified.
+  //
+  // See also:
+  // https://cloud.google.com/monitoring/api/ref_v3/rpc/google.api#google.api.MonitoredResource
+  // https://cloud.google.com/monitoring/api/resources
+  std::unordered_map<std::string, google::api::MonitoredResource>
+      per_view_monitored_resource;
+
   // Optional: the name prefix for Stackdriver metrics.
   //
   // It is suggested to use a prefix with a custom or external domain name, for

--- a/opencensus/exporters/stats/stackdriver/stackdriver_exporter.h
+++ b/opencensus/exporters/stats/stackdriver/stackdriver_exporter.h
@@ -52,8 +52,8 @@ struct StackdriverOptions {
   // descriptor name, value is the monitored resource to use for that view.
   //
   // If the view name cannot be found in the map, the exporter will use the
-  // "monitored_resource" set in option, or "global" resource if that is not
-  // specified.
+  // monitored_resource set above, or the "global" resource if that is not
+  // set.
   //
   // See also:
   // https://cloud.google.com/monitoring/api/ref_v3/rpc/google.api#google.api.MonitoredResource

--- a/opencensus/exporters/stats/stackdriver/stackdriver_exporter.h
+++ b/opencensus/exporters/stats/stackdriver/stackdriver_exporter.h
@@ -48,7 +48,7 @@ struct StackdriverOptions {
   // https://cloud.google.com/monitoring/api/resources
   google::api::MonitoredResource monitored_resource;
 
-  // Optional: per view Stackdriver MonitoredResource to use. Key is the view
+  // Optional: per metric Stackdriver MonitoredResource to use. Key is the view
   // descriptor name, value is the monitored resource to use for that view.
   //
   // If the view name cannot be found in the map, the exporter will use the
@@ -59,7 +59,7 @@ struct StackdriverOptions {
   // https://cloud.google.com/monitoring/api/ref_v3/rpc/google.api#google.api.MonitoredResource
   // https://cloud.google.com/monitoring/api/resources
   std::unordered_map<std::string, google::api::MonitoredResource>
-      per_view_monitored_resource;
+      per_metric_monitored_resource;
 
   // Optional: the name prefix for Stackdriver metrics.
   //


### PR DESCRIPTION
Follow up of #334. In addition to general custom monitored resource, also add per view custom monitored resource. This could be useful in the case of using envoy exporting istio metric, where inbound metrics attached to k8s_container MR and outbound metrics attached to k8s_pod (https://cloud.google.com/monitoring/api/metrics_anthos).