### PR TITLE
Stackdriver stats exporter: make opencensus_task optional.

### DIFF
--- a/opencensus/common/internal/BUILD
+++ b/opencensus/common/internal/BUILD
@@ -69,6 +69,16 @@ cc_library(
 # ========================================================================= #
 
 cc_test(
+    name = "hostname_test",
+    srcs = ["hostname_test.cc"],
+    copts = TEST_COPTS,
+    deps = [
+        ":hostname",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
     name = "random_test",
     srcs = ["random_test.cc"],
     copts = TEST_COPTS,

--- a/opencensus/common/internal/BUILD
+++ b/opencensus/common/internal/BUILD
@@ -27,6 +27,14 @@ cc_library(
 )
 
 cc_library(
+    name = "hostname",
+    srcs = ["hostname.cc"],
+    hdrs = ["hostname.h"],
+    copts = DEFAULT_COPTS,
+    deps = ["@com_google_absl//absl/strings"],
+)
+
+cc_library(
     name = "random_lib",
     srcs = ["random.cc"],
     hdrs = ["random.h"],

--- a/opencensus/common/internal/CMakeLists.txt
+++ b/opencensus/common/internal/CMakeLists.txt
@@ -36,6 +36,8 @@ target_compile_definitions(opencensus_common_stats_object INTERFACE
 
 opencensus_lib(common_string_vector_hash)
 
+opencensus_test(common_hostname_test hostname_test.cc common_hostname)
+
 opencensus_test(common_random_test random_test.cc common_random)
 
 opencensus_benchmark(common_random_benchmark random_benchmark.cc common_random)

--- a/opencensus/common/internal/CMakeLists.txt
+++ b/opencensus/common/internal/CMakeLists.txt
@@ -14,6 +14,12 @@
 
 opencensus_lib(common_hash_mix)
 
+opencensus_lib(common_hostname
+               SRCS
+               hostname.cc
+               DEPS
+               absl::strings)
+
 opencensus_lib(common_random
                SRCS
                random.cc

--- a/opencensus/common/internal/hostname.cc
+++ b/opencensus/common/internal/hostname.cc
@@ -14,7 +14,11 @@
 
 #include "opencensus/common/internal/hostname.h"
 
+#if defined(_MSC_VER)
+#include <process.h>
+#else
 #include <unistd.h>
+#endif
 
 #include "absl/strings/str_cat.h"
 

--- a/opencensus/common/internal/hostname.cc
+++ b/opencensus/common/internal/hostname.cc
@@ -15,8 +15,11 @@
 #include "opencensus/common/internal/hostname.h"
 
 #if defined(_MSC_VER)
+#define WIN32_LEAN_AND_MEAN
 #include <process.h>
-#include <winsock.h>
+#include <windows.h>
+#include <winsock2.h>
+#pragma comment(lib, "ws2_32.lib")
 #else
 #include <unistd.h>
 #endif
@@ -25,7 +28,27 @@
 
 namespace opencensus {
 namespace common {
+namespace {
+constexpr char kUnknownHostname[] = "unknown_hostname";
+}  // namespace
 
+#if defined(_MSC_VER)
+std::string Hostname() {
+  WSADATA data;
+  if (WSAStartup(MAKEWORD(2, 2), &data) != 0) {
+    return kUnknownHostname;
+  }
+  // SUSv2 says 255 is the limit for hostnames.
+  char buf[256];
+  if (gethostname(buf, sizeof(buf)) != 0) {
+    return kUnknownHostname;
+  }
+  // NUL terminate just in case.
+  buf[sizeof(buf) - 1] = 0;
+  WSACleanup();
+  return buf;
+}
+#else
 std::string Hostname() {
   // SUSv2 says 255 is the limit for hostnames.
   char buf[256];
@@ -36,6 +59,7 @@ std::string Hostname() {
   buf[sizeof(buf) - 1] = 0;
   return buf;
 }
+#endif
 
 std::string OpenCensusTask() {
   return absl::StrCat("cpp-", getpid(), "@", Hostname());

--- a/opencensus/common/internal/hostname.cc
+++ b/opencensus/common/internal/hostname.cc
@@ -16,6 +16,7 @@
 
 #if defined(_MSC_VER)
 #include <process.h>
+#include <winsock.h>
 #else
 #include <unistd.h>
 #endif

--- a/opencensus/common/internal/hostname.cc
+++ b/opencensus/common/internal/hostname.cc
@@ -1,0 +1,40 @@
+// Copyright 2019, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "opencensus/common/internal/hostname.h"
+
+#include <unistd.h>
+
+#include "absl/strings/str_cat.h"
+
+namespace opencensus {
+namespace common {
+
+std::string Hostname() {
+  // SUSv2 says 255 is the limit for hostnames.
+  char buf[256];
+  if (gethostname(buf, sizeof(buf)) == -1) {
+    return "unknown_hostname";
+  }
+  // gethostname() doesn't guarantee NUL termination.
+  buf[sizeof(buf) - 1] = 0;
+  return buf;
+}
+
+std::string OpenCensusTask() {
+  return absl::StrCat("cpp-", getpid(), "@", Hostname());
+}
+
+}  // namespace common
+}  // namespace opencensus

--- a/opencensus/common/internal/hostname.h
+++ b/opencensus/common/internal/hostname.h
@@ -24,7 +24,7 @@ namespace common {
 std::string Hostname();
 
 // Returns a default opencensus_task value for stats exporters, in
-// the format "cpp-${PID}@{HOSTNAME}"
+// the format "cpp-{PID}@{HOSTNAME}"
 std::string OpenCensusTask();
 
 }  // namespace common

--- a/opencensus/common/internal/hostname.h
+++ b/opencensus/common/internal/hostname.h
@@ -1,0 +1,33 @@
+// Copyright 2019, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef OPENCENSUS_COMMON_INTERNAL_HOST_H_
+#define OPENCENSUS_COMMON_INTERNAL_HOST_H_
+
+#include <string>
+
+namespace opencensus {
+namespace common {
+
+// Returns the current hostname or "unknown_hostname" on error.
+std::string Hostname();
+
+// Returns a default opencensus_task value for stats exporters, in
+// the format "cpp-${PID}@{HOSTNAME}"
+std::string OpenCensusTask();
+
+}  // namespace common
+}  // namespace opencensus
+
+#endif  // OPENCENSUS_COMMON_INTERNAL_HOST_H_

--- a/opencensus/common/internal/hostname_test.cc
+++ b/opencensus/common/internal/hostname_test.cc
@@ -1,0 +1,33 @@
+// Copyright 2019, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "opencensus/common/internal/hostname.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+#include <string>
+
+namespace opencensus {
+namespace common {
+namespace {
+
+TEST(HostnameTest, OpenCensusTaskSmokeTest) {
+  const std::string task = OpenCensusTask();
+  std::cout << "opencensus_task = \"" << task << "\"\n";
+  EXPECT_THAT(task, ::testing::StartsWith("cpp-"));
+}
+
+}  // namespace
+}  // namespace common
+}  // namespace opencensus

--- a/opencensus/exporters/stats/stackdriver/BUILD
+++ b/opencensus/exporters/stats/stackdriver/BUILD
@@ -26,6 +26,7 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         ":stackdriver_utils",
+        "//opencensus/common/internal:hostname",
         "//opencensus/common/internal/grpc:status",
         "//opencensus/common/internal/grpc:with_user_agent",
         "//opencensus/stats",

--- a/opencensus/exporters/stats/stackdriver/internal/stackdriver_exporter.cc
+++ b/opencensus/exporters/stats/stackdriver/internal/stackdriver_exporter.cc
@@ -30,6 +30,7 @@
 #include "google/protobuf/empty.pb.h"
 #include "opencensus/common/internal/grpc/status.h"
 #include "opencensus/common/internal/grpc/with_user_agent.h"
+#include "opencensus/common/internal/hostname.h"
 #include "opencensus/exporters/stats/stackdriver/internal/stackdriver_utils.h"
 #include "opencensus/stats/stats.h"
 
@@ -74,6 +75,10 @@ StackdriverOptions SetOptionDefaults(StackdriverOptions&& o) {
 
   // Prepend prefix because we always use this with a prefix.
   opts.project_id = absl::StrCat(kProjectIdPrefix, opts.project_id);
+
+  if (opts.opencensus_task.empty()) {
+    opts.opencensus_task = opencensus::common::OpenCensusTask();
+  }
 
   if (opts.metric_name_prefix.empty()) {
     opts.metric_name_prefix = kDefaultMetricNamePrefix;

--- a/opencensus/exporters/stats/stackdriver/stackdriver_exporter.h
+++ b/opencensus/exporters/stats/stackdriver/stackdriver_exporter.h
@@ -32,9 +32,9 @@ struct StackdriverOptions {
   // The Stackdriver project ID to use.
   std::string project_id;
 
-  // The opencensus_task is used to uniquely identify the task in Stackdriver.
-  // The recommended format is "{LANGUAGE}-{PID}@{HOSTNAME}". If PID is not
-  // available, a random number may be used.
+  // Optional: The opencensus_task is used to uniquely identify the task in
+  // Stackdriver. If empty, the exporter will use "{LANGUAGE}-{PID}@{HOSTNAME}"
+  // by default.
   std::string opencensus_task;
 
   // The RPC deadline to use when exporting to Stackdriver.

--- a/opencensus/exporters/stats/stackdriver/stackdriver_exporter.h
+++ b/opencensus/exporters/stats/stackdriver/stackdriver_exporter.h
@@ -33,8 +33,8 @@ struct StackdriverOptions {
   std::string project_id;
 
   // Optional: The opencensus_task is used to uniquely identify the task in
-  // Stackdriver. If empty, the exporter will use "{LANGUAGE}-{PID}@{HOSTNAME}"
-  // by default.
+  // Stackdriver. If empty, the exporter will use "cpp-{PID}@{HOSTNAME}" by
+  // default.
   std::string opencensus_task;
 
   // The RPC deadline to use when exporting to Stackdriver.


### PR DESCRIPTION
Have the exporter fill it in by default, and move the code out of
examples/ and into opencensus/common/internal/.