### PR TITLE
Build fix: provide a @bazel_version repository.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -50,6 +50,12 @@ load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
 
 grpc_deps()
 
+# gRPC depends on upb, which depends on a @bazel_version repo
+# which it provides but has to be instantiated explicitly.
+load("@upb//bazel:repository_defs.bzl", "bazel_version_repository")
+
+bazel_version_repository(name = "bazel_version")
+
 # Used by prometheus-cpp.
 local_repository(
     name = "net_zlib_zlib",


### PR DESCRIPTION
gRPC depends on upb which depends on bazel_version, which
has to be instantiated in WORKSPACE.

The bazel_version definition is here:

https://github.com/protocolbuffers/upb/blob/1ee1e362565f681fdd46f16bf9f70f51c905ddd4/bazel/repository_defs.bzl