### PR TITLE
Make default Stackdriver exporter deadlines match opencensus-java.

### DIFF
--- a/opencensus/exporters/stats/stackdriver/internal/stackdriver_exporter.cc
+++ b/opencensus/exporters/stats/stackdriver/internal/stackdriver_exporter.cc
@@ -145,8 +145,11 @@ void Handler::ExportViewData(
     if (ok) {
       const auto& s = status[(uintptr_t)tag];
       if (!s.ok()) {
-        std::cerr << "CreateTimeSeries request failed: "
-                  << opencensus::common::ToString(s) << "\n";
+        std::cerr << "CreateTimeSeries request failed (" << num_rpcs
+                  << " RPCs, " << data.size() << " views, "
+                  << time_series.size()
+                  << " timeseries): " << opencensus::common::ToString(s)
+                  << "\n";
       }
     }
   }
@@ -181,8 +184,9 @@ bool Handler::MaybeRegisterView(
   ::grpc::Status status = opts_.metric_service_stub->CreateMetricDescriptor(
       &context, request, &response);
   if (!status.ok()) {
-    std::cerr << "CreateMetricDescriptor request failed: "
-              << opencensus::common::ToString(status) << "\n";
+    std::cerr << "CreateMetricDescriptor(" << request.metric_descriptor().name()
+              << ") request failed: " << opencensus::common::ToString(status)
+              << "\n";
     return false;
   }
   registered_descriptors_.emplace_hint(it, descriptor.name(), descriptor);

--- a/opencensus/exporters/stats/stackdriver/stackdriver_exporter.h
+++ b/opencensus/exporters/stats/stackdriver/stackdriver_exporter.h
@@ -39,7 +39,7 @@ struct StackdriverOptions {
   std::string opencensus_task;
 
   // The RPC deadline to use when exporting to Stackdriver.
-  absl::Duration rpc_deadline = absl::Seconds(5);
+  absl::Duration rpc_deadline = absl::Seconds(60);
 
   // Optional: the Stackdriver MonitoredResource to use.
   //

--- a/opencensus/exporters/trace/stackdriver/internal/stackdriver_exporter.cc
+++ b/opencensus/exporters/trace/stackdriver/internal/stackdriver_exporter.cc
@@ -259,8 +259,9 @@ void Handler::Export(
   grpc::Status status =
       opts_.trace_service_stub->BatchWriteSpans(&context, request, &response);
   if (!status.ok()) {
-    std::cerr << "BatchWriteSpans failed: "
-              << opencensus::common::ToString(status) << "\n";
+    std::cerr << "BatchWriteSpans failed (" << spans.size() << " spans, "
+              << request.ByteSizeLong()
+              << " bytes): " << opencensus::common::ToString(status) << "\n";
   }
 }
 

--- a/opencensus/exporters/trace/stackdriver/stackdriver_exporter.h
+++ b/opencensus/exporters/trace/stackdriver/stackdriver_exporter.h
@@ -32,7 +32,7 @@ struct StackdriverOptions {
   std::string project_id;
 
   // The RPC deadline to use when exporting to Stackdriver.
-  absl::Duration rpc_deadline = absl::Seconds(5);
+  absl::Duration rpc_deadline = absl::Seconds(10);
 
   // (optional) By default, the exporter connects to Stackdriver using gRPC. If
   // this stub is non-null, the exporter will use this stub to send gRPC calls


### PR DESCRIPTION
Also improve logging when exporter RPCs fail.