### PR TITLE
Stackdriver stats: resource must uniquely identify a timeseries.

### DIFF
--- a/opencensus/exporters/stats/stackdriver/internal/stackdriver_exporter.cc
+++ b/opencensus/exporters/stats/stackdriver/internal/stackdriver_exporter.cc
@@ -112,11 +112,12 @@ void Handler::ExportViewData(
 
     const bool is_known_custom_metric = IsKnownCustomMetric(metric_type);
 
-    // If there is a non-default MonitoredResource for this view, it must
-    // uniquely identify the timeseries.
+    // If this is a custom metric, add the opencensus_task label so that
+    // different processes produce different timeseries instead of colliding.
     //
-    // Otherwise, we add the opencensus_task label so that different processes
-    // produce different timeseries instead of colliding.
+    // However, if there is a non-default MonitoredResource for this view, it
+    // must already uniquely identify the timeseries, so don't add the
+    // opencensus_task label.
     const bool add_task_label =
         is_known_custom_metric && (monitored_resource_for_view == nullptr);
 

--- a/opencensus/exporters/stats/stackdriver/internal/stackdriver_utils.h
+++ b/opencensus/exporters/stats/stackdriver/internal/stackdriver_utils.h
@@ -38,22 +38,29 @@ std::string MakeType(absl::string_view metric_name_prefix,
 // custom (i.e not built-in) Stackdriver metric.
 bool IsKnownCustomMetric(absl::string_view metric_type);
 
+// Returns a pointer to the MonitoredResource proto for this view, or nullptr if
+// the default resource should be used.
+const google::api::MonitoredResource* MonitoredResourceForView(
+    const opencensus::stats::ViewDescriptor& view_descriptor,
+    const google::api::MonitoredResource& monitored_resource,
+    const std::unordered_map<std::string, google::api::MonitoredResource>&
+        per_metric_monitored_resource);
+
 // Populates metric_descriptor. project_name must be in the format
 // "projects/project_id". metric_name_prefix must have a trailing slash, e.g.
 // "custom.googleapis.com/opencensus/".
 void SetMetricDescriptor(
     absl::string_view project_name, absl::string_view metric_name_prefix,
     const opencensus::stats::ViewDescriptor& view_descriptor,
-    google::api::MetricDescriptor* metric_descriptor);
+    bool add_task_label, google::api::MetricDescriptor* metric_descriptor);
 
-// Converts each row of 'data' into TimeSeries.
+// Converts each row of 'data' into a TimeSeries proto.
 std::vector<google::monitoring::v3::TimeSeries> MakeTimeSeries(
     absl::string_view metric_name_prefix,
-    const google::api::MonitoredResource& monitored_resource,
-    const std::unordered_map<std::string, google::api::MonitoredResource>&
-        per_metric_monitored_resource,
+    const google::api::MonitoredResource* monitored_resource_for_view,
     const opencensus::stats::ViewDescriptor& view_descriptor,
-    const opencensus::stats::ViewData& data, absl::string_view opencensus_task);
+    const opencensus::stats::ViewData& data, bool add_task_label,
+    absl::string_view opencensus_task);
 
 // Populates proto based on the given time.
 void SetTimestamp(absl::Time time, google::protobuf::Timestamp* proto);


### PR DESCRIPTION
- Don't add the opencensus_task label when a non-default
MonitoredResource is present.

- Refactor exporter code to reduce duplication of effort.