### PR TITLE
Fix invalidation of MeasureDescriptors.

### DIFF
--- a/opencensus/stats/internal/measure_registry_impl.cc
+++ b/opencensus/stats/internal/measure_registry_impl.cc
@@ -16,6 +16,7 @@
 
 #include <iostream>
 
+#include "absl/memory/memory.h"
 #include "opencensus/stats/internal/delta_producer.h"
 #include "opencensus/stats/internal/stats_manager.h"
 #include "opencensus/stats/measure_descriptor.h"
@@ -83,7 +84,8 @@ uint64_t MeasureRegistryImpl::RegisterImpl(MeasureDescriptor descriptor) {
   const uint64_t id =
       CreateMeasureId(registered_descriptors_.size(), true, descriptor.type());
   id_map_.emplace_hint(it, descriptor.name(), id);
-  registered_descriptors_.push_back(std::move(descriptor));
+  registered_descriptors_.push_back(
+      absl::make_unique<MeasureDescriptor>(std::move(descriptor)));
   return id;
 }
 
@@ -96,7 +98,7 @@ const MeasureDescriptor& MeasureRegistryImpl::GetDescriptorByName(
         MeasureDescriptor("", "", "", MeasureDescriptor::Type::kDouble);
     return default_descriptor;
   } else {
-    return registered_descriptors_[IdToIndex(it->second)];
+    return *registered_descriptors_[IdToIndex(it->second)];
   }
 }
 

--- a/opencensus/stats/internal/measure_registry_test.cc
+++ b/opencensus/stats/internal/measure_registry_test.cc
@@ -147,6 +147,20 @@ TEST(MeasureRegistryTest, GetMeasureByNameWithWrongTypeFails) {
   EXPECT_NE(measure_int.GetDescriptor(), measure_int_mistyped.GetDescriptor());
 }
 
+TEST(MeasureRegistryTest, GrowDescriptorVector) {
+  const std::string name = MakeUniqueName();
+  ASSERT_TRUE(MeasureDouble::Register(name, "desc", "units").IsValid());
+  const MeasureDescriptor& md = MeasureRegistry::GetDescriptorByName(name);
+
+  // Add descriptors until the vector of descriptors grows, moves, and
+  // invalidates md above.
+  for (int i = 0; i < 1000; ++i) {
+    EXPECT_EQ(MeasureDescriptor::Type::kDouble, md.type());
+    ASSERT_TRUE(
+        MeasureDouble::Register(MakeUniqueName(), "desc", "units").IsValid());
+  }
+}
+
 }  // namespace
 }  // namespace stats
 }  // namespace opencensus


### PR DESCRIPTION
Heap-allocate MeasureDescriptors so that references to them are stable
even if the underlying storage (std::vector) in the MeasureRegistry
moves.

Add test that fails under ASAN if this isn't done.