### PR TITLE
Tidy up BUILD files.

### DIFF
--- a/examples/helloworld/BUILD
+++ b/examples/helloworld/BUILD
@@ -22,7 +22,6 @@ cc_binary(
     name = "helloworld",
     srcs = ["helloworld.cc"],
     copts = DEFAULT_COPTS,
-    linkopts = ["-pthread"],  # Required for absl/synchronization bits.
     deps = [
         "//opencensus/exporters/stats/stdout:stdout_exporter",
         "//opencensus/exporters/trace/stdout:stdout_exporter",

--- a/opencensus/common/internal/BUILD
+++ b/opencensus/common/internal/BUILD
@@ -98,7 +98,6 @@ cc_binary(
     testonly = 1,
     srcs = ["random_benchmark.cc"],
     copts = TEST_COPTS,
-    linkopts = ["-pthread"],  # Required for absl/synchronization bits.
     linkstatic = 1,
     deps = [
         ":random_lib",
@@ -123,7 +122,6 @@ cc_binary(
     testonly = 1,
     srcs = ["timestamp_benchmark.cc"],
     copts = TEST_COPTS,
-    #linkopts = ["-pthread"],  # Required for absl/synchronization bits.
     linkstatic = 1,
     deps = [
         ":timestamp",

--- a/opencensus/context/BUILD
+++ b/opencensus/context/BUILD
@@ -78,7 +78,6 @@ cc_binary(
     testonly = 1,
     srcs = ["internal/context_benchmark.cc"],
     copts = TEST_COPTS,
-    linkopts = ["-pthread"],  # Required for absl/synchronization bits.
     linkstatic = 1,
     deps = [
         ":context",

--- a/opencensus/exporters/trace/ocagent/BUILD
+++ b/opencensus/exporters/trace/ocagent/BUILD
@@ -35,7 +35,6 @@ cc_library(
         "//opencensus/common/internal/grpc:with_user_agent",
         "//opencensus/trace",
         "@com_github_grpc_grpc//:grpc++",
-        "@com_google_absl//absl/base:core_headers",
         "@com_google_absl//absl/memory",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/time",

--- a/opencensus/exporters/trace/zipkin/BUILD
+++ b/opencensus/exporters/trace/zipkin/BUILD
@@ -34,7 +34,6 @@ cc_library(
         "//opencensus/trace",
         "@com_github_curl//:curl",
         "@com_github_tencent_rapidjson//:rapidjson",
-        "@com_google_absl//absl/base:core_headers",
         "@com_google_absl//absl/memory",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/time",

--- a/opencensus/stats/BUILD
+++ b/opencensus/stats/BUILD
@@ -252,7 +252,6 @@ cc_binary(
     testonly = 1,
     srcs = ["internal/stats_manager_benchmark.cc"],
     copts = TEST_COPTS,
-    linkopts = ["-pthread"],  # Required for absl/synchronization bits.
     linkstatic = 1,
     deps = [
         ":core",

--- a/opencensus/tags/BUILD
+++ b/opencensus/tags/BUILD
@@ -36,6 +36,7 @@ cc_library(
     deps = [
         "@com_google_absl//absl/base:core_headers",
         "@com_google_absl//absl/hash",
+        "@com_google_absl//absl/memory",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/synchronization",
     ],
@@ -88,6 +89,7 @@ cc_test(
     deps = [
         ":tags",
         "@com_google_absl//absl/hash",
+        "@com_google_absl//absl/strings",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -135,7 +137,6 @@ cc_binary(
     testonly = 1,
     srcs = ["internal/with_tag_map_benchmark.cc"],
     copts = TEST_COPTS,
-    linkopts = ["-pthread"],  # Required for absl/synchronization bits.
     linkstatic = 1,
     deps = [
         ":tags",


### PR DESCRIPTION
- Explicitly passing -pthread isn't needed anymore.
- Don't rely on transitive deps.
- Several targets didn't need core_headers.