### PR TITLE
[Stackdriver Exporter] Avoid sending time series that is 24h in the past

### DIFF
--- a/opencensus/exporters/stats/stackdriver/internal/stackdriver_exporter.cc
+++ b/opencensus/exporters/stats/stackdriver/internal/stackdriver_exporter.cc
@@ -103,6 +103,10 @@ void Handler::ExportViewData(
   absl::MutexLock l(&mu_);
   std::vector<google::monitoring::v3::TimeSeries> time_series;
   for (const auto& datum : data) {
+    if (IsDayOld(datum.second)) {
+      // Data point cannot be written if it is more than 24h in the past.
+      continue;
+    }
     const opencensus::stats::ViewDescriptor& descriptor = datum.first;
     const std::string metric_type =
         MakeType(opts_.metric_name_prefix, descriptor.name());

--- a/opencensus/exporters/stats/stackdriver/internal/stackdriver_utils.cc
+++ b/opencensus/exporters/stats/stackdriver/internal/stackdriver_utils.cc
@@ -163,6 +163,10 @@ bool IsKnownCustomMetric(absl::string_view metric_type) {
          absl::StartsWith(metric_type, "external.googleapis.com/");
 }
 
+bool IsDayOld(const opencensus::stats::ViewData& view_data) {
+  return absl::Now() - view_data.end_time() >= absl::Hours(24);
+}
+
 const google::api::MonitoredResource* MonitoredResourceForView(
     const opencensus::stats::ViewDescriptor& view_descriptor,
     const google::api::MonitoredResource& monitored_resource,

--- a/opencensus/exporters/stats/stackdriver/internal/stackdriver_utils.h
+++ b/opencensus/exporters/stats/stackdriver/internal/stackdriver_utils.h
@@ -38,6 +38,9 @@ std::string MakeType(absl::string_view metric_name_prefix,
 // custom (i.e not built-in) Stackdriver metric.
 bool IsKnownCustomMetric(absl::string_view metric_type);
 
+// Returns true if the given view data is more than 24h in the past.
+bool IsDayOld(const opencensus::stats::ViewData& view_data);
+
 // Returns a pointer to the MonitoredResource proto for this view, or nullptr if
 // the default resource should be used.
 const google::api::MonitoredResource* MonitoredResourceForView(


### PR DESCRIPTION
Reference: https://github.com/istio/istio/issues/18613

Not sure if stale view data (time series) is expected, maybe we need to track debugging of that. This is to put a quick bandaid to avoid sending data that the backend does not want.