### PR TITLE
Stackdriver stats: Return false in matcher when type is unknown

### DIFF
--- a/opencensus/exporters/stats/stackdriver/internal/time_series_matcher.cc
+++ b/opencensus/exporters/stats/stackdriver/internal/time_series_matcher.cc
@@ -124,6 +124,8 @@ bool TimeSeriesMatcher::MatchAndExplain(
       return true;
     }
   }
+  *listener << "has unknown type";
+  return false;
 }
 
 void TimeSeriesMatcher::DescribeTo(::std::ostream* os) const {


### PR DESCRIPTION
Before this change, when type was unknown, MatchAndExplain method could
return random data. This change adds default return of false value when
type does not match any handled bases.