### PR TITLE
Some debian package manager tweaks

### DIFF
--- a/tools/docker-format/Dockerfile
+++ b/tools/docker-format/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:cosmic
 
-RUN apt update && \
-    apt install -y clang-format golang git python-pip && \
+RUN apt-get update && \
+    apt-get --no-install-recommends install -y clang-format golang git python-pip && \
     go get -v github.com/bazelbuild/buildtools/buildifier && \
     pip install 'cmake_format>=0.5.2'
 


### PR DESCRIPTION
By default, Ubuntu or Debian based "apt" or "apt-get" system installs recommended but not suggested packages . 

By passing "--no-install-recommends" option, the user lets apt-get know not to consider recommended packages as a dependency to install.

This results in smaller downloads and installation of packages .

Refer to blog at [Ubuntu Blog](https://ubuntu.com/blog/we-reduced-our-docker-images-by-60-with-no-install-recommends) .

results in smaller image size.