### PR TITLE
Don't leave af_type uninitialized.

### DIFF
--- a/opencensus/exporters/trace/zipkin/internal/zipkin_exporter.cc
+++ b/opencensus/exporters/trace/zipkin/internal/zipkin_exporter.cc
@@ -102,15 +102,15 @@ void SerializeJson(const ::opencensus::trace::exporter::SpanData& span,
   writer->Key("id");
   writer->String(span.context().span_id().ToHex());
 
-  // Write endpoint.  OpenCensus does not support this by default.
+  // Write localEndpoint. OpenCensus does not support this by default.
   writer->Key("localEndpoint");
   writer->StartObject();
   writer->Key("serviceName");
   writer->String(service.service_name);
-  if (service.af_type == ZipkinExporterOptions::AddressFamily::kIpv6) {
-    writer->Key("ipv6");
-  } else {
+  if (service.af_type == ZipkinExporterOptions::AddressFamily::kIpv4) {
     writer->Key("ipv4");
+  } else {
+    writer->Key("ipv6");
   }
   writer->String(service.ip_address);
   writer->EndObject();

--- a/opencensus/exporters/trace/zipkin/internal/zipkin_exporter_test.cc
+++ b/opencensus/exporters/trace/zipkin/internal/zipkin_exporter_test.cc
@@ -29,7 +29,6 @@ class ZipkinExporterTestPeer : public ::testing::Test {
   ZipkinExporterTestPeer() {
     // Register zipkin exporter
     ZipkinExporterOptions options("http://127.0.0.1:9411/api/v2/spans");
-    options.af_type = ZipkinExporterOptions::AddressFamily::kIpv4;
     options.service_name = "TestService";
     ZipkinExporter::Register(options);
   }

--- a/opencensus/exporters/trace/zipkin/zipkin_exporter.h
+++ b/opencensus/exporters/trace/zipkin/zipkin_exporter.h
@@ -46,7 +46,7 @@ struct ZipkinExporterOptions {
   std::string service_name;
   // Address family to be reported to zipkin collector.
   enum class AddressFamily : uint8_t { kIpv4, kIpv6 };
-  AddressFamily af_type;
+  AddressFamily af_type = AddressFamily::kIpv4;
 
   struct Service {
     Service() : af_type(AddressFamily::kIpv4) {}


### PR DESCRIPTION
Always branch on af_type == v4, instead of mixing v4 and v6.