### PR TITLE
Update ViewData+StackdriverExporter to use a separate start_timestamp for each tag map.

### DIFF
--- a/opencensus/stats/examples/exporter_example.cc
+++ b/opencensus/stats/examples/exporter_example.cc
@@ -60,10 +60,12 @@ class ExampleExporter : public opencensus::stats::StatsExporter::Handler {
         return;
       }
       std::string output;
-      absl::StrAppend(&output, "\nData for view \"", descriptor.name(),
-                      "\" from ", absl::FormatTime(view_data.start_time()),
-                      " to ", absl::FormatTime(view_data.end_time()), ":\n");
+      absl::StrAppend(&output, "\nData for view \"", descriptor.name(), "\n");
       for (const auto& row : view_data.double_data()) {
+        auto start_time = view_data.start_times().at(row.first);
+        absl::StrAppend(&output, "\nRow data from ",
+                        absl::FormatTime(start_time), " to ",
+                        absl::FormatTime(view_data.end_time()), ":\n");
         for (int i = 0; i < descriptor.columns().size(); ++i) {
           absl::StrAppend(&output, descriptor.columns()[i].name(), ":",
                           row.first[i], ", ");

--- a/opencensus/stats/internal/view_data.cc
+++ b/opencensus/stats/internal/view_data.cc
@@ -81,6 +81,11 @@ const ViewData::DataMap<Distribution>& ViewData::distribution_data() const {
 }
 
 absl::Time ViewData::start_time() const { return impl_->start_time(); }
+
+const ViewData::DataMap<absl::Time>& ViewData::start_times() const {
+  return impl_->start_times();
+}
+
 absl::Time ViewData::end_time() const { return end_time_; }
 
 ViewData::ViewData(const ViewData& other)

--- a/opencensus/stats/internal/view_data_impl.h
+++ b/opencensus/stats/internal/view_data_impl.h
@@ -103,6 +103,12 @@ class ViewDataImpl {
     return interval_data_;
   }
 
+  // Returns a start time for each timeseries/tag map.
+  const DataMap<absl::Time>& start_times() const { return start_times_; }
+
+  // DEPRECATED: Legacy start_time_ for the entire view.
+  // This should be deleted if custom exporters are updated to
+  // use start_times_ and stop depending on this field.
   absl::Time start_time() const { return start_time_; }
 
   // Merges bulk data for the given tag values at 'now'. tag_values must be
@@ -120,6 +126,14 @@ class ViewDataImpl {
 
   Type TypeForDescriptor(const ViewDescriptor& descriptor);
 
+  void SetStartTimeIfUnset(const std::vector<std::string>& tag_values,
+                           absl::Time now) {
+    // If the time is not set.
+    if (start_times_.find(tag_values) == start_times_.end()) {
+      start_times_[tag_values] = now;
+    }
+  }
+
   const Aggregation aggregation_;
   const AggregationWindow aggregation_window_;
   const Type type_;
@@ -129,6 +143,13 @@ class ViewDataImpl {
     DataMap<Distribution> distribution_data_;
     DataMap<IntervalStatsObject> interval_data_;
   };
+
+  // A start time for each timeseries/tag map.
+  DataMap<absl::Time> start_times_;
+
+  // DEPRECATED: Legacy start_time_ for the entire view.
+  // This should be deleted if custom exporters are updated to
+  // use start_times_ and stop depending on this field
   absl::Time start_time_;
 };
 

--- a/opencensus/stats/internal/view_data_impl_test.cc
+++ b/opencensus/stats/internal/view_data_impl_test.cc
@@ -55,6 +55,8 @@ TEST(ViewDataImplTest, Sum) {
   EXPECT_EQ(Aggregation::Sum(), data.aggregation());
   EXPECT_EQ(AggregationWindow::Cumulative(), data.aggregation_window());
   EXPECT_EQ(start_time, data.start_time());
+  EXPECT_EQ(start_time, data.start_times().at(tags1));
+  EXPECT_EQ(end_time, data.start_times().at(tags2));
   EXPECT_THAT(data.double_data(),
               ::testing::UnorderedElementsAre(::testing::Pair(tags1, 3),
                                               ::testing::Pair(tags2, 5)));
@@ -76,6 +78,8 @@ TEST(ViewDataImplTest, Count) {
   EXPECT_EQ(Aggregation::Count(), data.aggregation());
   EXPECT_EQ(AggregationWindow::Cumulative(), data.aggregation_window());
   EXPECT_EQ(start_time, data.start_time());
+  EXPECT_EQ(start_time, data.start_times().at(tags1));
+  EXPECT_EQ(end_time, data.start_times().at(tags2));
   EXPECT_THAT(data.int_data(),
               ::testing::UnorderedElementsAre(::testing::Pair(tags1, 2),
                                               ::testing::Pair(tags2, 1)));
@@ -98,6 +102,8 @@ TEST(ViewDataImplTest, Distribution) {
   EXPECT_EQ(Aggregation::Distribution(buckets), data.aggregation());
   EXPECT_EQ(AggregationWindow::Cumulative(), data.aggregation_window());
   EXPECT_EQ(start_time, data.start_time());
+  EXPECT_EQ(start_time, data.start_times().at(tags1));
+  EXPECT_EQ(end_time, data.start_times().at(tags2));
   EXPECT_EQ(data.distribution_data().size(), 2);
   EXPECT_THAT(data.distribution_data().find(tags1)->second.bucket_counts(),
               ::testing::ElementsAre(2, 0));
@@ -124,6 +130,8 @@ TEST(ViewDataImplTest, LastValueDouble) {
   EXPECT_EQ(Aggregation::LastValue(), data.aggregation());
   EXPECT_EQ(AggregationWindow::Cumulative(), data.aggregation_window());
   EXPECT_EQ(start_time, data.start_time());
+  EXPECT_EQ(start_time, data.start_times().at(tags1));
+  EXPECT_EQ(end_time, data.start_times().at(tags2));
   EXPECT_THAT(data.double_data(),
               ::testing::UnorderedElementsAre(::testing::Pair(tags1, 5.0),
                                               ::testing::Pair(tags2, 15.0)));
@@ -148,6 +156,8 @@ TEST(ViewDataImplTest, LastValueInt64) {
   EXPECT_EQ(Aggregation::LastValue(), data.aggregation());
   EXPECT_EQ(AggregationWindow::Cumulative(), data.aggregation_window());
   EXPECT_EQ(start_time, data.start_time());
+  EXPECT_EQ(start_time, data.start_times().at(tags1));
+  EXPECT_EQ(end_time, data.start_times().at(tags2));
   EXPECT_THAT(data.int_data(),
               ::testing::UnorderedElementsAre(::testing::Pair(tags1, 5),
                                               ::testing::Pair(tags2, 15)));
@@ -174,12 +184,16 @@ TEST(ViewDataImplTest, StatsObjectToCount) {
   EXPECT_EQ(AggregationWindow::Interval(interval),
             export_data1.aggregation_window());
   EXPECT_EQ(start_time, export_data1.start_time());
+  EXPECT_EQ(start_time, export_data1.start_times().at(tags1));
+  EXPECT_EQ(start_time, export_data1.start_times().at(tags2));
   EXPECT_THAT(export_data1.double_data(),
               ::testing::UnorderedElementsAre(::testing::Pair(tags1, 3),
                                               ::testing::Pair(tags2, 1)));
 
   const ViewDataImpl export_data2(data, time + interval);
   EXPECT_EQ(time, export_data2.start_time());
+  EXPECT_EQ(start_time, export_data1.start_times().at(tags1));
+  EXPECT_EQ(start_time, export_data1.start_times().at(tags2));
   EXPECT_THAT(export_data2.double_data(),
               ::testing::UnorderedElementsAre(::testing::Pair(tags1, 1),
                                               ::testing::Pair(tags2, 0)));
@@ -206,12 +220,16 @@ TEST(ViewDataImplTest, StatsObjectToSum) {
   EXPECT_EQ(AggregationWindow::Interval(interval),
             export_data1.aggregation_window());
   EXPECT_EQ(start_time, export_data1.start_time());
+  EXPECT_EQ(start_time, export_data1.start_times().at(tags1));
+  EXPECT_EQ(start_time, export_data1.start_times().at(tags2));
   EXPECT_THAT(export_data1.double_data(),
               ::testing::UnorderedElementsAre(::testing::Pair(tags1, 6),
                                               ::testing::Pair(tags2, 2)));
 
   const ViewDataImpl export_data2(data, time + interval);
   EXPECT_EQ(time, export_data2.start_time());
+  EXPECT_EQ(start_time, export_data1.start_times().at(tags1));
+  EXPECT_EQ(start_time, export_data1.start_times().at(tags2));
   EXPECT_THAT(export_data2.double_data(),
               ::testing::UnorderedElementsAre(::testing::Pair(tags1, 2),
                                               ::testing::Pair(tags2, 0)));
@@ -240,6 +258,8 @@ TEST(ViewDataImplTest, StatsObjectToDistribution) {
   EXPECT_EQ(AggregationWindow::Interval(interval),
             export_data1.aggregation_window());
   EXPECT_EQ(start_time, export_data1.start_time());
+  EXPECT_EQ(start_time, export_data1.start_times().at(tags1));
+  EXPECT_EQ(start_time, export_data1.start_times().at(tags2));
   EXPECT_EQ(2, export_data1.distribution_data().size());
   const Distribution& distribution_1_1 =
       export_data1.distribution_data().find(tags1)->second;
@@ -260,6 +280,8 @@ TEST(ViewDataImplTest, StatsObjectToDistribution) {
 
   const ViewDataImpl export_data2(data, time + interval);
   EXPECT_EQ(time, export_data2.start_time());
+  EXPECT_EQ(time, export_data2.start_times().at(tags1));
+  EXPECT_EQ(time, export_data2.start_times().at(tags2));
   EXPECT_EQ(2, export_data2.distribution_data().size());
   const Distribution& distribution_1_2 =
       export_data2.distribution_data().find(tags1)->second;

--- a/opencensus/stats/testing/test_utils.h
+++ b/opencensus/stats/testing/test_utils.h
@@ -29,12 +29,25 @@ namespace opencensus {
 namespace stats {
 namespace testing {
 
+// Struct to be used as parameters to MakeViewData functions.
+struct TestViewValue {
+  std::vector<std::string> tag_values;
+  double value;
+  absl::Time start_time;
+};
+
 class TestUtils final {
  public:
+  // Makes a ViewData, using absl::UnixEpoch() as the start time.
   static ViewData MakeViewData(
       const ViewDescriptor& descriptor,
       std::initializer_list<std::pair<std::vector<std::string>, double>>
           values);
+
+  // Makes a ViewData, using the specified start times for each timeseries.
+  static ViewData MakeViewDataWithStartTimes(
+      const ViewDescriptor& descriptor,
+      const std::vector<TestViewValue>& view_values);
 
   static Distribution MakeDistribution(const BucketBoundaries* buckets);
 

--- a/opencensus/stats/view_data.h
+++ b/opencensus/stats/view_data.h
@@ -69,7 +69,15 @@ class ViewData {
   const DataMap<int64_t>& int_data() const;
   const DataMap<Distribution>& distribution_data() const;
 
+  // DEPRECATED: Returns a start time for the view data.
   absl::Time start_time() const;
+
+  // A map from tag values (corresponding to the keys in the ViewDescriptor, in
+  // that order) to the start time for those tags.
+  // The start time stored represents the first time a point was seen with
+  // that combination of tag values.
+  const DataMap<absl::Time>& start_times() const;
+
   absl::Time end_time() const;
 
   ViewData(const ViewData& other);


### PR DESCRIPTION
This fixes a bug reporting metrics to stackdriver. Cumulative timeseries metrics in Stackdriver should report a start time which contains the first set of points updated for that timeseries.

Before this PR, the start_time was picked once for the view (regardless of which tagmap was exporting a timeseries). This causes issues in Stackdriver when a new timeseries(i.e. a new tagmap for the same view) is reported to Stackdriver at a later time. Stackdriver has internal mechanisms which can cause those initial points to be dropped.