### PR TITLE
Disable signed/unsigned comparison warnings

### DIFF
--- a/opencensus/copts.bzl
+++ b/opencensus/copts.bzl
@@ -32,15 +32,16 @@ load(
 )
 
 WERROR = ["-Werror=return-type", "-Werror=switch"]
+WARN_FLAGS = ["-Wno-sign-compare"]
 
 DEFAULT_COPTS = select({
-    "//opencensus:llvm_compiler": ABSL_LLVM_FLAGS + WERROR,
+    "//opencensus:llvm_compiler": ABSL_LLVM_FLAGS + WERROR + WARN_FLAGS,
     "//opencensus:windows": ABSL_MSVC_FLAGS,
-    "//conditions:default": ABSL_GCC_FLAGS + WERROR,
+    "//conditions:default": ABSL_GCC_FLAGS + WERROR + WARN_FLAGS,
 })
 
 TEST_COPTS = DEFAULT_COPTS + select({
-    "//opencensus:llvm_compiler": ABSL_LLVM_TEST_FLAGS + WERROR,
+    "//opencensus:llvm_compiler": ABSL_LLVM_TEST_FLAGS + WERROR + WARN_FLAGS,
     "//opencensus:windows": ABSL_MSVC_TEST_FLAGS,
-    "//conditions:default": ABSL_GCC_TEST_FLAGS + WERROR,
+    "//conditions:default": ABSL_GCC_TEST_FLAGS + WERROR + WARN_FLAGS,
 })


### PR DESCRIPTION
OpenCensus compares signed and unsigned values throughout the code. This appears to be a conscious decision, and one that many projects take.

It also relies on Abseil to provide a sane set of compile/warning flags. However, Abseil has recently (https://github.com/abseil/abseil-cpp/commit/5bf048b8425cc0a342e4647932de19e25ffd6ad7) stopped disabling warnings for signed/unsigned comparisons.

The base set of flags provided by Abseil no longer align with OpenCensus's approach. So, this PR adds an additional warning flag to disable these warnings directly.