### PR TITLE
Silence -Wsign-compare compiler warning.

### DIFF
--- a/opencensus/trace/internal/span_exporter_impl.cc
+++ b/opencensus/trace/internal/span_exporter_impl.cc
@@ -65,7 +65,7 @@ void SpanExporterImpl::StartExportThread() {
 
 bool SpanExporterImpl::IsBatchFull() const {
   span_mu_.AssertHeld();
-  return spans_.size() >= cached_batch_size_;
+  return spans_.size() >= static_cast<size_t>(cached_batch_size_);
 }
 
 void SpanExporterImpl::RunWorkerLoop() {


### PR DESCRIPTION
Fixing this message from clang:
```
opencensus/trace/internal/span_exporter_impl.cc:68:24: warning: comparison of integers of different signs: 'std::vector::size_type' (aka 'unsigned long') and 'const int' [-Wsign-compare]
  return spans_.size() >= cached_batch_size_;
         ~~~~~~~~~~~~~ ^  ~~~~~~~~~~~~~~~~~~
1 warning generated.
```