### PR TITLE
Updates rules_cc branch from master to main

### DIFF
--- a/bazel/deps.bzl
+++ b/bazel/deps.bzl
@@ -7,8 +7,8 @@ def opencensus_cpp_deps():
     maybe(
         http_archive,
         name = "rules_cc",
-        strip_prefix = "rules_cc-master",
-        urls = ["https://github.com/bazelbuild/rules_cc/archive/master.zip"],
+        strip_prefix = "rules_cc-main",
+        urls = ["https://github.com/bazelbuild/rules_cc/archive/main.zip"],
     )
 
     # We depend on Abseil.


### PR DESCRIPTION
Will fix oss-fuzz build failure
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=35847

cc @jsuereth

cf log
```
Step #4: WARNING: Download from https://github.com/bazelbuild/rules_cc/archive/master.zip failed: class com.google.devtools.build.lib.bazel.repository.downloader.UnrecoverableHttpException GET returned 404 Not Found
Step #4: ERROR: An error occurred during the fetch of repository 'rules_cc':
Step #4:    Traceback (most recent call last):
Step #4: 	File "/root/.cache/bazel/_bazel_root/a93ad4e922dc92c27d422e6beddc7326/external/bazel_tools/tools/build_defs/repo/http.bzl", line 111, column 45, in _http_archive_impl
Step #4: 		download_info = ctx.download_and_extract(
Step #4: Error in download_and_extract: java.io.IOException: Error downloading [https://github.com/bazelbuild/rules_cc/archive/master.zip] to 
```