### PR TITLE
Stackdriver exporter: add workload.googleapis.com as a supported external domain

### DIFF
--- a/opencensus/exporters/stats/stackdriver/internal/stackdriver_utils.cc
+++ b/opencensus/exporters/stats/stackdriver/internal/stackdriver_utils.cc
@@ -172,7 +172,8 @@ std::string MakeType(absl::string_view metric_name_prefix,
 
 bool IsKnownCustomMetric(absl::string_view metric_type) {
   return absl::StartsWith(metric_type, "custom.googleapis.com/") ||
-         absl::StartsWith(metric_type, "external.googleapis.com/");
+         absl::StartsWith(metric_type, "external.googleapis.com/") ||
+         absl::StartsWith(metric_type, "workload.googleapis.com/");
 }
 
 const google::api::MonitoredResource* MonitoredResourceForView(


### PR DESCRIPTION
This allows metric descriptors to be created for metrics in that domain