### PR TITLE
cmake improvement

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -11,3 +11,24 @@ jobs:
       - uses: actions/checkout@v3
       - run: env BAZEL_CXXOPTS=-std=c++14 bazel build -k //...
       - run: env BAZEL_CXXOPTS=-std=c++14 bazel test -k //... --test_tag_filters=-noci
+  build-and-test-cmake:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build
+        run : |
+          set -eux
+          
+          CPUS=$(grep -c ^processor /proc/cpuinfo)
+          
+          mkdir ${GITHUB_WORKSPACE}/build && cd ${GITHUB_WORKSPACE}/build
+          cmake -DCMAKE_BUILD_TYPE=Release -DOpenCensus_BUILD_TESTING=ON -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install ..
+          make -j ${CPUS}
+          make install
+
+      - name: Test
+        run: |
+          set -eux
+          CPUS=$(grep -c ^processor /proc/cpuinfo)
+          cd ${GITHUB_WORKSPACE}/build
+          make test -j ${CPUS}

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # IntelliJ IDEA
 .idea
 *.iml
+/cmake-build-*
 
 # Eclipse
 .classpath

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ project(
   LANGUAGES CXX)
 
 option(FUZZER "Either OFF or e.g. -fsanitize=fuzzer,address" OFF)
+option(OpenCensus_BUILD_TESTING "build test and example" OFF)
 
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 11)
@@ -46,6 +47,21 @@ include(OpenCensusHelpers)
 add_subdirectory(opencensus)
 
 # Example code only if testing is enabled.
-if(BUILD_TESTING)
+if(BUILD_TESTING AND OpenCensus_BUILD_TESTING)
   add_subdirectory(examples)
 endif()
+
+install(DIRECTORY ${CMAKE_SOURCE_DIR}/opencensus TYPE INCLUDE FILES_MATCHING PATTERN "*.h")
+
+install(EXPORT OpenCensusTargets
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/OpenCensus
+  NAMESPACE ${PROJECT_NAME}::)
+
+include(CMakePackageConfigHelpers)
+
+configure_package_config_file(cmake/OpenCensusConfig.cmake.in
+  ${CMAKE_CURRENT_BINARY_DIR}/OpenCensusConfig.cmake
+  INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/OpenCensus)
+
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/OpenCensusConfig.cmake
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/OpenCensus)

--- a/cmake/OpenCensusConfig.cmake.in
+++ b/cmake/OpenCensusConfig.cmake.in
@@ -1,0 +1,4 @@
+@PACKAGE_INIT@
+
+include(${CMAKE_CURRENT_LIST_DIR}/OpenCensusTargets.cmake)
+check_required_components(OpenCensus)

--- a/opencensus/common/internal/CMakeLists.txt
+++ b/opencensus/common/internal/CMakeLists.txt
@@ -26,7 +26,7 @@ opencensus_lib(
 opencensus_lib(common_stats_object DEPS absl::time)
 
 # Define NOMINMAX to fix build errors when compiling with MSVC.
-target_compile_definitions(opencensus_common_stats_object
+target_compile_definitions(common_stats_object
                            INTERFACE $<$<CXX_COMPILER_ID:MSVC>:NOMINMAX>)
 
 opencensus_lib(common_string_vector_hash DEPS absl::hash)

--- a/opencensus/stats/CMakeLists.txt
+++ b/opencensus/stats/CMakeLists.txt
@@ -57,7 +57,7 @@ opencensus_lib(
   absl::span)
 
 # Define NOMINMAX to fix build errors when compiling with MSVC.
-target_compile_definitions(opencensus_stats_core
+target_compile_definitions(stats_core
                            PUBLIC $<$<CXX_COMPILER_ID:MSVC>:NOMINMAX>)
 
 opencensus_lib(

--- a/opencensus/trace/CMakeLists.txt
+++ b/opencensus/trace/CMakeLists.txt
@@ -50,7 +50,7 @@ opencensus_lib(
   absl::span)
 
 # Define NOMINMAX to fix build errors when compiling with MSVC.
-target_compile_definitions(opencensus_trace
+target_compile_definitions(trace
                            PUBLIC $<$<CXX_COMPILER_ID:MSVC>:NOMINMAX>)
 
 opencensus_lib(


### PR DESCRIPTION
1. support install and find_package
2. fix dependencies version
3. use external abseil and prometheus-cpp if possible
4. fix abseil build option
5. add flag to disable test
6. fix issue that target name is different if is included as sub directory
7. enable ci for cmake build