### PR TITLE
Stats StackDriverExporter: Always add task label for known custom metrics

### DIFF
--- a/opencensus/exporters/stats/stackdriver/internal/stackdriver_exporter.cc
+++ b/opencensus/exporters/stats/stackdriver/internal/stackdriver_exporter.cc
@@ -116,12 +116,7 @@ void Handler::ExportViewData(
 
     // If this is a custom metric, add the opencensus_task label so that
     // different processes produce different timeseries instead of colliding.
-    //
-    // However, if there is a non-default MonitoredResource for this view, it
-    // must already uniquely identify the timeseries, so don't add the
-    // opencensus_task label.
-    const bool add_task_label =
-        is_known_custom_metric && (monitored_resource_for_view == nullptr);
+    const bool add_task_label = is_known_custom_metric;
 
     // Builtin metrics are already defined, skip registration.
     if (is_known_custom_metric) {


### PR DESCRIPTION
We previously assumed that task labels are not needed if a non-default MonitoredResource is used, and that a MonitoredResource would be able to identify the timeseries, but this assumption breaks in the following cases -
1) Application is running under GCE, but there are two binaries running on the same VM. In this case, the MonitoredResource for both binaries would be the same. It would get `gce_instance` as the type and the labels `project_id`, `instance_id` and `zone` would be the same for both binaries.
2) If for some reason, the binary is unable to identify the GCP MonitoredResource and ends up using "global", we would still want to unique identify it from other binaries, and still be able to create unique time series for the two.